### PR TITLE
feat(highscores): most-deaths category and top-5 rankings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -32,7 +32,9 @@
       "Bash(gh project:*)",
       "Bash(gh issue:*)",
       "Bash(npx supabase:*)",
-      "Bash(rm:*)"
+      "Bash(rm:*)",
+      "Bash(git checkout:*)",
+      "Bash(git remote:*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,15 @@ Tables: `players`, `characters` (seed), `endings` (seed), `games`, `game_players
 
 Migrations live in `supabase/migrations/` and are applied via Supabase CLI. Seed data (characters, endings) is included in the initial migration.
 
+### Supabase workflow
+
+- The project is linked to a hosted Supabase instance — there is no local docker DB. All changes go directly to the hosted project.
+- Schema changes are made by creating a new migration file in `supabase/migrations/` named `YYYYMMDDHHMMSS_short_description.sql`, then running `npx supabase db push` to apply it.
+- **Never** modify existing migration files that are already applied remotely — always add a new one. The remote `schema_migrations` table tracks applied versions, and `db push` errors if local files don't match remote history.
+- **Never** delete migration files from `supabase/migrations/` unless they've also been reverted on the remote. Deleted local files cause `db push` to fail with "Remote migration versions not found".
+- If `db push` complains about missing local migrations, restore them from git (`git checkout -- supabase/migrations/<file>`) rather than repairing history as reverted.
+- Destructive or risky migrations (dropping columns, renaming tables, backfills) should be confirmed with the user before running `db push`.
+
 ### Data model conventions
 
 - Supabase columns use `snake_case`. In JS, top-level object fields are mapped to `camelCase` (e.g. `created_at` → `createdAt`), but nested DB-shaped rows (like `game.players[].is_winner`) keep their `snake_case` field names to avoid churn when passing row data through components.

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -6,49 +6,70 @@ const CATEGORY_LABELS = {
   most_followers: 'Most Followers',
   most_objects: 'Most Objects',
   most_denizens_on_spot: 'Most Denizens on Spot',
+  most_deaths: 'Most Deaths in One Game',
 }
 
 export function useHighscoreRecords() {
   return useQuery({
     queryKey: ['highscoreRecords'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('game_highscores')
-        .select(`
-          category,
-          value,
-          player:players ( id, name ),
-          game:games ( id, date )
-        `)
-      if (error) throw error
+      const [highscoresResult, deathsResult] = await Promise.all([
+        supabase
+          .from('game_highscores')
+          .select(`
+            category,
+            value,
+            player:players ( id, name ),
+            game:games ( id, date )
+          `),
+        supabase
+          .from('game_players')
+          .select(`
+            total_deaths,
+            player:players ( id, name ),
+            game:games ( id, date )
+          `)
+          .order('total_deaths', { ascending: false })
+          .limit(5),
+      ])
 
-      const bestByCategory = new Map()
-      for (const row of data) {
-        const current = bestByCategory.get(row.category)
-        if (!current || Number(row.value) > Number(current.value)) {
-          bestByCategory.set(row.category, row)
-        }
+      if (highscoresResult.error) throw highscoresResult.error
+
+      const topByCategory = new Map()
+      for (const row of highscoresResult.data) {
+        if (!topByCategory.has(row.category)) topByCategory.set(row.category, [])
+        topByCategory.get(row.category).push(row)
+      }
+      for (const [category, rows] of topByCategory) {
+        rows.sort((a, b) => Number(b.value) - Number(a.value))
+        topByCategory.set(category, rows.slice(0, 5))
+      }
+
+      const deathsRows = deathsResult.data ?? []
+      if (deathsRows.length > 0) {
+        topByCategory.set(
+          'most_deaths',
+          deathsRows.map((r) => ({
+            category: 'most_deaths',
+            value: r.total_deaths,
+            player: r.player,
+            game: r.game,
+          }))
+        )
       }
 
       return Object.keys(CATEGORY_LABELS).map((category) => {
-        const best = bestByCategory.get(category)
-        if (!best) {
-          return {
-            category,
-            label: CATEGORY_LABELS[category],
-            player: null,
-            value: null,
-            game_date: null,
-            game_id: null,
-          }
-        }
+        const rows = topByCategory.get(category) ?? []
         return {
           category,
           label: CATEGORY_LABELS[category],
-          player: best.player?.name ?? null,
-          value: best.value,
-          game_date: best.game?.date ?? null,
-          game_id: best.game?.id ?? null,
+          entries: rows.map((row, _i, arr) => ({
+            rank: arr.findIndex((r) => Number(r.value) === Number(row.value)) + 1,
+            player: row.player?.name ?? null,
+            value: row.value,
+            game_date: row.game?.date ?? null,
+            game_id: row.game?.id ?? null,
+          })),
         }
       })
     },

--- a/src/lib/gameWrites.js
+++ b/src/lib/gameWrites.js
@@ -14,13 +14,18 @@ export function buildGamePlayerRows(gameId, formState) {
   })
 }
 
+const GAME_LEVEL_HIGHSCORES = new Set(['most_denizens_on_spot'])
+
 export function buildHighscoreRows(gameId, formState) {
   const rows = []
   for (const [category, entry] of Object.entries(formState.highscores ?? {})) {
-    if (!entry?.player_id || entry.value === '' || entry.value == null) continue
+    if (!entry) continue
+    if (entry.value === '' || entry.value == null) continue
+    const isGameLevel = GAME_LEVEL_HIGHSCORES.has(category)
+    if (!isGameLevel && !entry.player_id) continue
     rows.push({
       game_id: gameId,
-      player_id: entry.player_id,
+      player_id: isGameLevel ? null : entry.player_id,
       category,
       value: Number(entry.value),
     })

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -30,7 +30,7 @@ export default function EditGame() {
       return acc
     }, {}),
     highscores: game.highscores.reduce((acc, h) => {
-      acc[h.category] = { player_id: h.player.id, value: h.value }
+      acc[h.category] = { player_id: h.player?.id ?? '', value: h.value }
       return acc
     }, {}),
     expansionEvents: game.players.reduce((acc, gp) => {

--- a/src/pages/GameDetail.jsx
+++ b/src/pages/GameDetail.jsx
@@ -185,7 +185,9 @@ export default function GameDetail() {
                   <p className="text-sm font-heading text-parchment/80 tracking-wide">
                     {CATEGORY_LABELS[hs.category] || hs.category}
                   </p>
-                  <p className="text-gold/70 text-sm font-body mt-0.5">{hs.player?.name}</p>
+                  <p className="text-gold/70 text-sm font-body mt-0.5">
+                    {hs.player?.name ?? 'Game record'}
+                  </p>
                 </div>
                 <span className="text-gold font-display text-2xl">{hs.value}</span>
               </div>

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -29,6 +29,15 @@ const CATEGORY_ICONS = {
       <polyline points="22 8.5 12 15.5 2 8.5" />
     </svg>
   ),
+  most_deaths: (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2a8 8 0 0 0-8 8c0 3 1.5 5.5 4 7v3h8v-3c2.5-1.5 4-4 4-7a8 8 0 0 0-8-8z" />
+      <line x1="9" y1="17" x2="9" y2="21" />
+      <line x1="15" y1="17" x2="15" y2="21" />
+      <circle cx="9" cy="10" r="1" fill="currentColor" />
+      <circle cx="15" cy="10" r="1" fill="currentColor" />
+    </svg>
+  ),
 }
 
 export default function HighscoresBoard() {
@@ -49,30 +58,54 @@ export default function HighscoresBoard() {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {records.map((record, i) => {
-          const empty = record.value == null
+          const empty = record.entries.length === 0
+          const [gold, ...rest] = record.entries
           return (
             <div
               key={record.category}
               className={`card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 animate-fade-up delay-${i + 2}`}
             >
-              <div className="flex items-start justify-between mb-4">
+              <div className="flex items-start justify-between mb-3">
                 <div className="text-gold/50">{CATEGORY_ICONS[record.category]}</div>
-                <span className="text-gold font-display text-3xl tracking-wider leading-none">
-                  {empty ? '—' : record.value}
-                </span>
-              </div>
-              <h3 className="font-heading text-parchment text-lg tracking-wide mb-2">{record.label}</h3>
-              <div className="flex items-center justify-between text-sm font-body">
-                <span className="text-gold/80">{record.player ?? 'No record yet'}</span>
                 {!empty && (
-                  <Link
-                    to={`/games/${record.game_id}`}
-                    className="text-muted hover:text-teal-light transition-colors"
-                  >
-                    {new Date(record.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                  </Link>
+                  <span className="text-gold font-display text-3xl tracking-wider leading-none">
+                    {gold.value}
+                  </span>
                 )}
               </div>
+              <h3 className="font-heading text-parchment text-lg tracking-wide mb-3">{record.label}</h3>
+
+              {empty ? (
+                <p className="text-muted text-sm font-body">No record yet</p>
+              ) : (
+                <ol className="space-y-1.5">
+                  {record.entries.map((entry) => (
+                    <li key={entry.rank} className="flex items-center justify-between text-sm font-body">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className={`w-4 shrink-0 text-right font-display ${entry.rank === 1 ? 'text-gold' : 'text-muted/60'}`}>
+                          {entry.rank}
+                        </span>
+                        <span className={`truncate ${entry.rank === 1 ? 'text-gold/90' : 'text-parchment/70'}`}>
+                          {entry.player ?? 'Talisman'}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0 ml-2">
+                        <span className={`font-display ${entry.rank === 1 ? 'text-parchment' : 'text-muted'}`}>
+                          {entry.value}
+                        </span>
+                        {entry.game_id && (
+                          <Link
+                            to={`/games/${entry.game_id}`}
+                            className="text-muted/50 hover:text-teal-light transition-colors text-xs"
+                          >
+                            {new Date(entry.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                          </Link>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
             </div>
           )
         })}

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -9,10 +9,10 @@ import { useUpdateGame } from '../hooks/useUpdateGame'
 import { useDeleteGame } from '../hooks/useDeleteGame'
 
 const HIGHSCORE_CATEGORIES = [
-  { key: 'most_coins', label: 'Most Coins' },
-  { key: 'most_followers', label: 'Most Followers' },
-  { key: 'most_objects', label: 'Most Objects' },
-  { key: 'most_denizens_on_spot', label: 'Most Denizens on Spot' },
+  { key: 'most_coins', label: 'Most Coins', gameLevel: false },
+  { key: 'most_followers', label: 'Most Followers', gameLevel: false },
+  { key: 'most_objects', label: 'Most Objects', gameLevel: false },
+  { key: 'most_denizens_on_spot', label: 'Most Denizens on Spot', gameLevel: true },
 ]
 
 const WOODLAND_PATHS = [
@@ -310,30 +310,32 @@ export default function LogGame({ initialData, isEditing, gameId }) {
           )}
           {showAddPlayer && (
             <div className="mt-4">
-              <div className="flex gap-2">
+              <div className="space-y-2">
                 <input
-                  className="input-field flex-1"
+                  className="input-field w-full"
                   placeholder="New player name"
                   value={newPlayerName}
                   onChange={e => setNewPlayerName(e.target.value)}
                   onKeyDown={e => { if (e.key === 'Enter') handleAddPlayerInline() }}
                   autoFocus
                 />
-                <button
-                  type="button"
-                  className="btn-outline text-sm"
-                  onClick={() => { setShowAddPlayer(false); setNewPlayerName(''); addPlayer.reset() }}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="btn-gold text-sm"
-                  onClick={handleAddPlayerInline}
-                  disabled={!newPlayerName.trim() || addPlayer.isPending}
-                >
-                  {addPlayer.isPending ? 'Adding...' : 'Add'}
-                </button>
+                <div className="flex gap-2 justify-end">
+                  <button
+                    type="button"
+                    className="btn-outline text-sm"
+                    onClick={() => { setShowAddPlayer(false); setNewPlayerName(''); addPlayer.reset() }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-gold text-sm"
+                    onClick={handleAddPlayerInline}
+                    disabled={!newPlayerName.trim() || addPlayer.isPending}
+                  >
+                    {addPlayer.isPending ? 'Adding...' : 'Add'}
+                  </button>
+                </div>
               </div>
               {addPlayer.error && (
                 <p className="text-danger text-xs font-body mt-2">{addPlayer.error.message}</p>
@@ -446,17 +448,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
             {HIGHSCORE_CATEGORIES.map(cat => (
               <div key={cat.key} className="bg-surface border border-gold-dim/15 rounded-xl p-4">
                 <label className="block text-sm font-heading text-parchment/80 tracking-wide mb-3">{cat.label}</label>
-                <div className="grid grid-cols-2 gap-3">
-                  <select
-                    className="input-field text-sm"
-                    value={form.highscores[cat.key]?.player_id || ''}
-                    onChange={e => updateHighscore(cat.key, 'player_id', e.target.value)}
-                  >
-                    <option value="">Player...</option>
-                    {selectedPlayers.map(p => (
-                      <option key={p.id} value={p.id}>{p.name}</option>
-                    ))}
-                  </select>
+                {cat.gameLevel ? (
                   <input
                     type="number"
                     min="0"
@@ -465,7 +457,28 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                     value={form.highscores[cat.key]?.value || ''}
                     onChange={e => updateHighscore(cat.key, 'value', e.target.value)}
                   />
-                </div>
+                ) : (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <select
+                      className="input-field text-sm"
+                      value={form.highscores[cat.key]?.player_id || ''}
+                      onChange={e => updateHighscore(cat.key, 'player_id', e.target.value)}
+                    >
+                      <option value="">Player...</option>
+                      {selectedPlayers.map(p => (
+                        <option key={p.id} value={p.id}>{p.name}</option>
+                      ))}
+                    </select>
+                    <input
+                      type="number"
+                      min="0"
+                      className="input-field text-sm"
+                      placeholder="Value"
+                      value={form.highscores[cat.key]?.value || ''}
+                      onChange={e => updateHighscore(cat.key, 'value', e.target.value)}
+                    />
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/supabase/migrations/20260413000000_denizens_game_level.sql
+++ b/supabase/migrations/20260413000000_denizens_game_level.sql
@@ -1,0 +1,9 @@
+-- ============================================================
+-- Phase 5 — Game-level denizens highscore
+-- ============================================================
+-- `most_denizens_on_spot` is a per-game record (a spot on the
+-- board, not attributable to a single player), so player_id is
+-- no longer required on game_highscores rows.
+
+alter table game_highscores
+  alter column player_id drop not null;


### PR DESCRIPTION
## Summary

- Add **Most Deaths in One Game** highscore category, sourced from `game_players.total_deaths`
- Show **top-5 entries** per category on Highscores Board instead of a single all-time record
- Fix game-level highscores (`most_denizens_on_spot`) to not require a player selection — was blocking save
- Mobile: fix cramped add-player form (input now stacks above buttons), highscore grid goes single-column on small screens

## Test plan

- [ ] Log a game with denizens on spot value — confirm it saves without selecting a player
- [ ] Highscores board shows up to 5 ranked entries per category
- [ ] Most Deaths card appears and populates from existing game data
- [ ] Add Player inline form on mobile (≤390px) no longer overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)