### PR TITLE
feat(log-game): add highscore categories, replace character list, order expansions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -34,11 +34,13 @@
       "Bash(npx supabase:*)",
       "Bash(rm:*)",
       "Bash(git checkout:*)",
-
       "Bash(git remote:*)",
       "Bash(gh pr create --title 'feat\\(highscores\\): most-deaths category and top-5 rankings' --body ':*)",
-      "Bash(git stash:*)"
-
+      "Bash(git stash:*)",
+      "Bash(git push:*)",
+      "Skill(pr)",
+      "Bash(git fetch:*)",
+      "Bash(git rm:*)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -6,63 +6,38 @@ const CATEGORY_LABELS = {
   most_followers: 'Most Followers',
   most_objects: 'Most Objects',
   most_fate: 'Most Fate',
-  most_strength: 'Most Strength (without bonus)',
-  most_craft: 'Most Craft (without bonus)',
+  most_strength: 'Most Strength',
+  most_craft: 'Most Craft',
   most_life: 'Most Life',
   most_deaths: 'Most Deaths',
   most_toad_times: 'Most Times Turned Into Toad',
-  longest_toad_streak: 'Longest Toad Streak (consecutive turns)',
+  longest_toad_streak: 'Longest Toad Streak',
   most_denizens_on_spot: 'Most Denizens on Spot',
-  most_deaths: 'Most Deaths in One Game',
 }
 
 export function useHighscoreRecords() {
   return useQuery({
     queryKey: ['highscoreRecords'],
     queryFn: async () => {
-      const [highscoresResult, deathsResult] = await Promise.all([
-        supabase
-          .from('game_highscores')
-          .select(`
-            category,
-            value,
-            player:players ( id, name ),
-            game:games ( id, date )
-          `),
-        supabase
-          .from('game_players')
-          .select(`
-            total_deaths,
-            player:players ( id, name ),
-            game:games ( id, date )
-          `)
-          .order('total_deaths', { ascending: false })
-          .limit(5),
-      ])
+      const { data, error } = await supabase
+        .from('game_highscores')
+        .select(`
+          category,
+          value,
+          player:players ( id, name ),
+          game:games ( id, date )
+        `)
 
-      if (highscoresResult.error) throw highscoresResult.error
+      if (error) throw error
 
       const topByCategory = new Map()
-      for (const row of highscoresResult.data) {
+      for (const row of data) {
         if (!topByCategory.has(row.category)) topByCategory.set(row.category, [])
         topByCategory.get(row.category).push(row)
       }
       for (const [category, rows] of topByCategory) {
         rows.sort((a, b) => Number(b.value) - Number(a.value))
         topByCategory.set(category, rows.slice(0, 5))
-      }
-
-      const deathsRows = deathsResult.data ?? []
-      if (deathsRows.length > 0) {
-        topByCategory.set(
-          'most_deaths',
-          deathsRows.map((r) => ({
-            category: 'most_deaths',
-            value: r.total_deaths,
-            player: r.player,
-            game: r.game,
-          }))
-        )
       }
 
       return Object.keys(CATEGORY_LABELS).map((category) => {

--- a/src/lib/gameWrites.js
+++ b/src/lib/gameWrites.js
@@ -18,17 +18,20 @@ const GAME_LEVEL_HIGHSCORES = new Set(['most_denizens_on_spot'])
 
 export function buildHighscoreRows(gameId, formState) {
   const rows = []
-  for (const [category, entry] of Object.entries(formState.highscores ?? {})) {
-    if (!entry) continue
-    if (entry.value === '' || entry.value == null) continue
+  for (const [category, entries] of Object.entries(formState.highscores ?? {})) {
+    if (!Array.isArray(entries)) continue
     const isGameLevel = GAME_LEVEL_HIGHSCORES.has(category)
-    if (!isGameLevel && !entry.player_id) continue
-    rows.push({
-      game_id: gameId,
-      player_id: isGameLevel ? null : entry.player_id,
-      category,
-      value: Number(entry.value),
-    })
+    for (const entry of entries) {
+      if (!entry) continue
+      if (entry.value === '' || entry.value == null) continue
+      if (!isGameLevel && !entry.player_id) continue
+      rows.push({
+        game_id: gameId,
+        player_id: isGameLevel ? null : entry.player_id,
+        category,
+        value: Number(entry.value),
+      })
+    }
   }
   return rows
 }

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -30,7 +30,8 @@ export default function EditGame() {
       return acc
     }, {}),
     highscores: game.highscores.reduce((acc, h) => {
-      acc[h.category] = { player_id: h.player?.id ?? '', value: h.value }
+      if (!acc[h.category]) acc[h.category] = []
+      acc[h.category].push({ player_id: h.player?.id ?? '', value: h.value })
       return acc
     }, {}),
     expansionEvents: game.players.reduce((acc, gp) => {

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -73,15 +73,6 @@ const CATEGORY_ICONS = {
       <polyline points="22 8.5 12 15.5 2 8.5" />
     </svg>
   ),
-  most_deaths: (
-    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12 2a8 8 0 0 0-8 8c0 3 1.5 5.5 4 7v3h8v-3c2.5-1.5 4-4 4-7a8 8 0 0 0-8-8z" />
-      <line x1="9" y1="17" x2="9" y2="21" />
-      <line x1="15" y1="17" x2="15" y2="21" />
-      <circle cx="9" cy="10" r="1" fill="currentColor" />
-      <circle cx="15" cy="10" r="1" fill="currentColor" />
-    </svg>
-  ),
 }
 
 export default function HighscoresBoard() {
@@ -109,54 +100,45 @@ export default function HighscoresBoard() {
               key={record.category}
               className={`card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 animate-fade-up delay-${i + 2}`}
             >
-              <div className="flex items-start justify-between mb-3">
+              <div className="flex items-start justify-between mb-1">
                 <div className="text-gold/50">{CATEGORY_ICONS[record.category]}</div>
                 <span className={`font-display text-3xl tracking-wider leading-none ${empty ? 'text-muted/40' : 'text-gold'}`}>
-                  {empty ? '×' : record.value}
+                  {empty ? '×' : gold.value}
                 </span>
               </div>
-              <h3 className="font-heading text-parchment text-lg tracking-wide mb-2">{record.label}</h3>
-              <div className="flex items-center justify-between text-sm font-body">
-                <span className="text-gold/80">{record.player ?? 'No record yet'}</span>
+              <h3 className="font-heading text-parchment text-2xl tracking-wide mb-3">{record.label}</h3>
+              {empty && <p className="text-muted text-sm font-body mb-3">No record yet</p>}
 
-                {!empty && (
-                  <span className="text-gold font-display text-3xl tracking-wider leading-none">
-                    {gold.value}
-                  </span>
-                )}
-              </div>
-              <h3 className="font-heading text-parchment text-lg tracking-wide mb-3">{record.label}</h3>
-
-              {empty ? (
-                <p className="text-muted text-sm font-body">No record yet</p>
-              ) : (
-                <ol className="space-y-1.5">
-                  {record.entries.map((entry) => (
-                    <li key={entry.rank} className="flex items-center justify-between text-sm font-body">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className={`w-4 shrink-0 text-right font-display ${entry.rank === 1 ? 'text-gold' : 'text-muted/60'}`}>
-                          {entry.rank}
-                        </span>
-                        <span className={`truncate ${entry.rank === 1 ? 'text-gold/90' : 'text-parchment/70'}`}>
-                          {entry.player ?? 'Talisman'}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-3 shrink-0 ml-2">
-                        <span className={`font-display ${entry.rank === 1 ? 'text-parchment' : 'text-muted'}`}>
-                          {entry.value}
-                        </span>
-                        {entry.game_id && (
-                          <Link
-                            to={`/games/${entry.game_id}`}
-                            className="text-muted/50 hover:text-teal-light transition-colors text-xs"
-                          >
-                            {new Date(entry.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                          </Link>
-                        )}
-                      </div>
-                    </li>
-                  ))}
-                </ol>
+              {!empty && (
+                <div className="border-t border-gold-dim/10 pt-3">
+                  <ol className="space-y-1.5">
+                    {record.entries.map((entry, idx) => (
+                      <li key={entry.rank} className={`flex items-center justify-between text-sm font-body px-2 py-1 rounded ${idx % 2 === 0 ? 'bg-gold/[0.04]' : ''}`}>
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className={`w-4 shrink-0 text-right font-display ${entry.rank === 1 ? 'text-gold' : 'text-muted/60'}`}>
+                            {entry.rank}
+                          </span>
+                          <span className={`truncate ${entry.rank === 1 ? 'text-gold/90' : 'text-parchment/70'}`}>
+                            {entry.player ?? 'Talisman'}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-3 shrink-0 ml-2">
+                          <span className={`font-display ${entry.rank === 1 ? 'text-parchment' : 'text-muted'}`}>
+                            {entry.value}
+                          </span>
+                          {entry.game_id && (
+                            <Link
+                              to={`/games/${entry.game_id}`}
+                              className="text-muted/50 hover:text-teal-light transition-colors text-xs"
+                            >
+                              {new Date(entry.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                            </Link>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ol>
+                </div>
               )}
             </div>
           )

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -9,19 +9,17 @@ import { useUpdateGame } from '../hooks/useUpdateGame'
 import { useDeleteGame } from '../hooks/useDeleteGame'
 
 const HIGHSCORE_CATEGORIES = [
-
   { key: 'most_gold', label: 'Most Gold' },
   { key: 'most_followers', label: 'Most Followers' },
   { key: 'most_objects', label: 'Most Objects' },
   { key: 'most_fate', label: 'Most Fate' },
-  { key: 'most_strength', label: 'Most Strength (without bonus)' },
-  { key: 'most_craft', label: 'Most Craft (without bonus)' },
+  { key: 'most_strength', label: 'Most Strength' },
+  { key: 'most_craft', label: 'Most Craft' },
   { key: 'most_life', label: 'Most Life' },
   { key: 'most_deaths', label: 'Most Deaths' },
   { key: 'most_toad_times', label: 'Most Times Turned Into Toad' },
-  { key: 'longest_toad_streak', label: 'Longest Toad Streak (consecutive turns)' },
-  { key: 'most_denizens_on_spot', label: 'Most Denizens on Spot' },
-
+  { key: 'longest_toad_streak', label: 'Longest Toad Streak' },
+  { key: 'most_denizens_on_spot', label: 'Most Denizens on Spot', gameLevel: true },
 ]
 
 const WOODLAND_PATHS = [
@@ -56,8 +54,40 @@ function SectionHeader({ title, subtitle }) {
   )
 }
 
+function StepNode({ number, label, status }) {
+  const isActive = status === 'active'
+  const isDone = status === 'done'
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div className={[
+        'w-9 h-9 rounded-full flex items-center justify-center font-heading text-sm font-bold border-2 transition-all duration-300',
+        isActive ? 'border-gold bg-gold text-deep shadow-[0_0_16px_rgba(201,168,76,0.4)]' : '',
+        isDone ? 'border-gold bg-gold/20 text-gold' : '',
+        !isActive && !isDone ? 'border-gold-dim/40 bg-transparent text-muted' : '',
+      ].filter(Boolean).join(' ')}>
+        {isDone ? '\u2713' : number}
+      </div>
+      <span className={`text-xs font-body tracking-wide whitespace-nowrap ${isActive ? 'text-gold' : 'text-muted'}`}>
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function StepIndicator({ step }) {
+  return (
+    <div className="flex items-center justify-center mb-10 animate-fade-up">
+      <StepNode number={1} label="Game Details" status={step > 1 ? 'done' : 'active'} />
+      <div className={`w-24 h-px mx-3 transition-all duration-500 ${step > 1 ? 'bg-gold' : 'bg-gold-dim/30'}`} />
+      <StepNode number={2} label="Highscores" status={step === 2 ? 'active' : 'idle'} />
+    </div>
+  )
+}
+
 export default function LogGame({ initialData, isEditing, gameId }) {
   const navigate = useNavigate()
+  const [step, setStep] = useState(1)
+  const [step1Attempted, setStep1Attempted] = useState(false)
   const [form, setForm] = useState(initialData || INITIAL_STATE)
   const [showAddPlayer, setShowAddPlayer] = useState(false)
   const [newPlayerName, setNewPlayerName] = useState('')
@@ -139,14 +169,35 @@ export default function LogGame({ initialData, isEditing, gameId }) {
     )
   }
 
-  const updateHighscore = (category, field, value) => {
+  const addHighscoreEntry = (category) => {
     setForm(prev => ({
       ...prev,
       highscores: {
         ...prev.highscores,
-        [category]: { ...prev.highscores[category], [field]: value },
+        [category]: [...(prev.highscores[category] || []), { player_id: '', value: '' }],
       },
     }))
+  }
+
+  const updateHighscoreEntry = (category, idx, field, value) => {
+    setForm(prev => {
+      const entries = [...(prev.highscores[category] || [])]
+      entries[idx] = { ...entries[idx], [field]: value }
+      return { ...prev, highscores: { ...prev.highscores, [category]: entries } }
+    })
+  }
+
+  const removeHighscoreEntry = (category, idx) => {
+    setForm(prev => {
+      const entries = (prev.highscores[category] || []).filter((_, i) => i !== idx)
+      const highscores = { ...prev.highscores }
+      if (entries.length === 0) {
+        delete highscores[category]
+      } else {
+        highscores[category] = entries
+      }
+      return { ...prev, highscores }
+    })
   }
 
   const toggleWoodlandPath = (playerId, path) => {
@@ -189,15 +240,21 @@ export default function LogGame({ initialData, isEditing, gameId }) {
     })
   }
 
-  const validationErrors = {
+  const playersWithNoCharacter = form.players.filter(
+    id => !form.playerData[id]?.characters_played?.length,
+  )
+  const step1Errors = {
     date: !form.date ? 'Date is required' : null,
     ending_id: !form.ending_id ? 'Ending is required' : null,
     players: form.players.length < 2 ? 'Select at least 2 players' : null,
+    characters: playersWithNoCharacter.length > 0
+      ? 'Every player needs at least one character'
+      : null,
   }
-  const hasErrors = Object.values(validationErrors).some(Boolean)
+  const step1HasErrors = Object.values(step1Errors).some(Boolean)
 
   const handleSubmit = () => {
-    if (hasErrors) return
+    if (step1HasErrors || hasHighscoreDuplicates || hasHighscoreMissingPlayer) return
     if (isEditing) {
       updateGame.mutate(
         { gameId, formState: form },
@@ -221,16 +278,49 @@ export default function LogGame({ initialData, isEditing, gameId }) {
   const submitError = logGame.error || updateGame.error || deleteGame.error
 
   const selectedPlayers = form.players.map(id => allPlayers.find(p => p.id === id)).filter(Boolean)
+  const expansionOrder = [
+    'Base Game', 'The Reaper', 'The Frostmarch', 'The Dragon', 'The Woodland',
+    'The City', 'The Harbinger', 'The Firelands', 'The Cataclysm', 'The Dungeon',
+    'The Sacred Pool', 'The Blood Moon',
+  ]
   const charactersByExpansion = allCharacters.reduce((acc, c) => {
     if (!acc[c.expansion]) acc[c.expansion] = []
     acc[c.expansion].push(c)
     return acc
   }, {})
+  const orderedExpansions = expansionOrder.filter(e => charactersByExpansion[e])
+
+  const totalHighscoreEntries = Object.values(form.highscores).reduce(
+    (sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0),
+    0,
+  )
+
+  const highscoreDuplicates = HIGHSCORE_CATEGORIES.reduce((acc, cat) => {
+    if (cat.gameLevel) return acc
+    const entries = form.highscores[cat.key] || []
+    const seen = new Set()
+    for (const entry of entries) {
+      if (!entry.player_id) continue
+      if (seen.has(entry.player_id)) { acc[cat.key] = true; break }
+      seen.add(entry.player_id)
+    }
+    return acc
+  }, {})
+
+  const highscoreMissingPlayer = HIGHSCORE_CATEGORIES.reduce((acc, cat) => {
+    if (cat.gameLevel) return acc
+    const entries = form.highscores[cat.key] || []
+    const hasMissing = entries.some(e => (e.value !== '' && e.value != null) && !e.player_id)
+    if (hasMissing) acc[cat.key] = true
+    return acc
+  }, {})
+
+  const hasHighscoreDuplicates = Object.keys(highscoreDuplicates).length > 0
+  const hasHighscoreMissingPlayer = Object.keys(highscoreMissingPlayer).length > 0
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      {/* Page title */}
-      <div className="mb-8 animate-fade-up">
+      <div className="mb-6 animate-fade-up">
         <h1 className="font-heading text-3xl text-parchment tracking-wide">
           {isEditing ? 'Edit Game' : 'Log a Game'}
         </h1>
@@ -239,318 +329,419 @@ export default function LogGame({ initialData, isEditing, gameId }) {
         </div>
       </div>
 
-      <div className="space-y-2">
-        {/* ── Game Setup ── */}
-        <section className="animate-fade-up delay-1">
-          <SectionHeader title="Game Setup" subtitle="When did the battle take place?" />
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-body text-parchment/80 mb-1.5">Date</label>
-              <input
-                type="date"
-                className="input-field"
-                value={form.date}
-                onChange={e => updateForm('date', e.target.value)}
-              />
-              {validationErrors.date && (
-                <p className="text-danger text-xs mt-1 font-body">{validationErrors.date}</p>
-              )}
-            </div>
-            <div>
-              <label className="block text-sm font-body text-parchment/80 mb-1.5">Ending Type</label>
-              <select
-                className="input-field"
-                value={form.ending_id}
-                onChange={e => updateForm('ending_id', e.target.value)}
-              >
-                <option value="">Select an ending...</option>
-                {allEndings.map(e => (
-                  <option key={e.id} value={e.id}>{e.name} ({e.expansion})</option>
-                ))}
-              </select>
-              {validationErrors.ending_id && (
-                <p className="text-danger text-xs mt-1 font-body">{validationErrors.ending_id}</p>
-              )}
-            </div>
-            <div>
-              <label className="block text-sm font-body text-parchment/80 mb-1.5">Notes (optional)</label>
-              <textarea
-                className="input-field min-h-[80px] resize-y"
-                placeholder="Any memorable moments..."
-                value={form.notes}
-                onChange={e => updateForm('notes', e.target.value)}
-              />
-            </div>
-          </div>
-        </section>
+      <StepIndicator step={step} />
 
-        {/* ── Players ── */}
-        <section className="animate-fade-up delay-2">
-          <SectionHeader title="Players" subtitle="Select 2-5 adventurers" />
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {allPlayers.map(player => {
-              const selected = form.players.includes(player.id)
-              return (
-                <button
-                  key={player.id}
-                  type="button"
-                  onClick={() => togglePlayer(player.id)}
-                  className={`p-3 rounded-lg border text-left font-body transition-all duration-200 ${
-                    selected
-                      ? 'border-gold bg-gold/10 text-gold'
-                      : 'border-gold-dim/20 bg-surface text-parchment/70 hover:border-gold-dim/40'
-                  }`}
+      {/* ── STEP 1: Game Details ── */}
+      {step === 1 && (
+        <div className="space-y-2">
+          {/* Game Setup */}
+          <section className="animate-fade-up delay-1">
+            <SectionHeader title="Game Setup" subtitle="When did the battle take place?" />
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-body text-parchment/80 mb-1.5">Date</label>
+                <input
+                  type="date"
+                  className="input-field"
+                  value={form.date}
+                  onChange={e => updateForm('date', e.target.value)}
+                />
+                {step1Attempted && step1Errors.date && (
+                  <p className="text-danger text-xs mt-1 font-body">{step1Errors.date}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-body text-parchment/80 mb-1.5">Ending Type</label>
+                <select
+                  className="input-field"
+                  value={form.ending_id}
+                  onChange={e => updateForm('ending_id', e.target.value)}
                 >
-                  <span className="text-sm font-medium">{player.name}</span>
-                  {selected && <span className="ml-2 text-gold/60 text-xs">&#10003;</span>}
-                </button>
-              )
-            })}
+                  <option value="">Select an ending...</option>
+                  {allEndings.map(e => (
+                    <option key={e.id} value={e.id}>{e.name} ({e.expansion})</option>
+                  ))}
+                </select>
+                {step1Attempted && step1Errors.ending_id && (
+                  <p className="text-danger text-xs mt-1 font-body">{step1Errors.ending_id}</p>
+                )}
+              </div>
+              <div>
+                <label className="block text-sm font-body text-parchment/80 mb-1.5">Notes (optional)</label>
+                <textarea
+                  className="input-field min-h-[80px] resize-y"
+                  placeholder="Any memorable moments..."
+                  value={form.notes}
+                  onChange={e => updateForm('notes', e.target.value)}
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* Players */}
+          <section className="animate-fade-up delay-2">
+            <SectionHeader title="Players" subtitle="Select 2-5 adventurers" />
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+              {allPlayers.map(player => {
+                const selected = form.players.includes(player.id)
+                return (
+                  <button
+                    key={player.id}
+                    type="button"
+                    onClick={() => togglePlayer(player.id)}
+                    className={`p-3 rounded-lg border text-left font-body transition-all duration-200 ${
+                      selected
+                        ? 'border-gold bg-gold/10 text-gold'
+                        : 'border-gold-dim/20 bg-surface text-parchment/70 hover:border-gold-dim/40'
+                    }`}
+                  >
+                    <span className="text-sm font-medium">{player.name}</span>
+                    {selected && <span className="ml-2 text-gold/60 text-xs">&#10003;</span>}
+                  </button>
+                )
+              })}
+              <button
+                type="button"
+                onClick={() => setShowAddPlayer(true)}
+                className="p-3 rounded-lg border border-dashed border-teal/30 text-teal-light/70 hover:border-teal hover:text-teal-light text-sm font-body transition-colors"
+              >
+                + Add Player
+              </button>
+            </div>
+            {step1Attempted && step1Errors.players && (
+              <p className="text-danger text-sm mt-2 font-body">{step1Errors.players}</p>
+            )}
+            {showAddPlayer && (
+              <div className="mt-4">
+                <div className="space-y-2">
+                  <input
+                    className="input-field w-full"
+                    placeholder="New player name"
+                    value={newPlayerName}
+                    onChange={e => setNewPlayerName(e.target.value)}
+                    onKeyDown={e => { if (e.key === 'Enter') handleAddPlayerInline() }}
+                    autoFocus
+                  />
+                  <div className="flex gap-2 justify-end">
+                    <button
+                      type="button"
+                      className="btn-outline text-sm"
+                      onClick={() => { setShowAddPlayer(false); setNewPlayerName(''); addPlayer.reset() }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-gold text-sm"
+                      onClick={handleAddPlayerInline}
+                      disabled={!newPlayerName.trim() || addPlayer.isPending}
+                    >
+                      {addPlayer.isPending ? 'Adding...' : 'Add'}
+                    </button>
+                  </div>
+                </div>
+                {addPlayer.error && (
+                  <p className="text-danger text-xs font-body mt-2">{addPlayer.error.message}</p>
+                )}
+              </div>
+            )}
+          </section>
+
+          {/* Per Player Data (includes expansion events) */}
+          {selectedPlayers.length > 0 && (
+            <section className="animate-fade-up delay-3">
+              <SectionHeader title="Player Details" subtitle="Characters, deaths, expansions, and the champion" />
+              <div className="space-y-6">
+                {selectedPlayers.map(player => {
+                  const data = form.playerData[player.id]
+                  const events = form.expansionEvents[player.id] ?? emptyPlayerEvents()
+                  if (!data) return null
+                  return (
+                    <div key={player.id} className="bg-surface border border-gold-dim/15 rounded-xl p-5">
+                      <div className="flex items-center justify-between mb-4">
+                        <h3 className="font-heading text-lg text-parchment tracking-wide">{player.name}</h3>
+                        <label className="flex items-center gap-2 cursor-pointer">
+                          <input
+                            type="checkbox"
+                            checked={data.is_winner}
+                            onChange={() => toggleWinner(player.id)}
+                            className="accent-gold w-4 h-4"
+                          />
+                          <span className={`text-sm font-body ${data.is_winner ? 'text-gold' : 'text-muted'}`}>
+                            Winner
+                          </span>
+                        </label>
+                      </div>
+
+                      {/* Characters played */}
+                      <div className="mb-4">
+                        <label className="block text-sm font-body text-parchment/70 mb-2">Characters Played (in order)</label>
+                        <div className="flex flex-wrap gap-2 mb-2">
+                          {data.characters_played.map((char, idx) => (
+                            <span
+                              key={idx}
+                              className="inline-flex items-center gap-1.5 bg-elevated px-3 py-1 rounded-full text-sm font-body text-parchment/80"
+                            >
+                              <span className="text-gold-dim text-xs">{idx + 1}.</span>
+                              {char}
+                              <button
+                                type="button"
+                                onClick={() => removeCharacter(player.id, idx)}
+                                className="text-muted hover:text-danger ml-0.5 transition-colors"
+                              >
+                                &times;
+                              </button>
+                            </span>
+                          ))}
+                        </div>
+                        <select
+                          className="input-field text-sm"
+                          value=""
+                          onChange={e => addCharacter(player.id, e.target.value)}
+                        >
+                          <option value="">Add a character...</option>
+                          {orderedExpansions.map(exp => (
+                            <optgroup key={exp} label={exp}>
+                              {chars.map(c => (
+                                <option key={c.id} value={c.name}>{c.name}</option>
+                              ))}
+                            </optgroup>
+                          ))}
+                        </select>
+                        {step1Attempted && playersWithNoCharacter.includes(player.id) && (
+                          <p className="text-danger text-xs mt-1.5 font-body">Add at least one character</p>
+                        )}
+                      </div>
+
+                      {/* Deaths */}
+                      <div className="mb-4">
+                        <label className="block text-sm font-body text-parchment/70 mb-1.5">Total Deaths</label>
+                        <input
+                          type="number"
+                          min="0"
+                          className="input-field w-24"
+                          value={data.total_deaths}
+                          onChange={e => updatePlayerData(player.id, 'total_deaths', parseInt(e.target.value) || 0)}
+                        />
+                      </div>
+
+                      {/* Winning character override */}
+                      {data.is_winner && (
+                        <div className="mb-4 p-3 bg-gold/5 border border-gold/20 rounded-lg">
+                          <label className="block text-sm font-body text-gold/80 mb-1.5">Winning Character</label>
+                          <select
+                            className="input-field text-sm"
+                            value={data.winning_character || ''}
+                            onChange={e => updatePlayerData(player.id, 'winning_character', e.target.value)}
+                          >
+                            <option value="">Select...</option>
+                            {data.characters_played.map((char, idx) => (
+                              <option key={idx} value={char}>{char}</option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+
+                      {/* Expansion Events */}
+                      <div className="border-t border-gold-dim/15 pt-4 mt-2">
+                        <p className="text-xs font-heading text-muted uppercase tracking-widest mb-3">Expansion Events</p>
+
+                        <div className="mb-3">
+                          <h4 className="font-heading text-xs text-teal-light tracking-wide uppercase mb-2">Woodland — Paths Completed</h4>
+                          <div className="flex flex-wrap gap-2">
+                            {WOODLAND_PATHS.map(path => {
+                              const selected = events.woodland.paths_completed.includes(path)
+                              return (
+                                <button
+                                  key={path}
+                                  type="button"
+                                  onClick={() => toggleWoodlandPath(player.id, path)}
+                                  className={`px-3 py-1.5 rounded-full text-sm font-body border transition-colors ${
+                                    selected
+                                      ? 'border-teal bg-teal/15 text-teal-light'
+                                      : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
+                                  }`}
+                                >
+                                  {path}
+                                </button>
+                              )
+                            })}
+                          </div>
+                        </div>
+
+                        <div>
+                          <h4 className="font-heading text-xs text-teal-light tracking-wide uppercase mb-2">Dungeon</h4>
+                          <label className="flex items-center gap-3 cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={events.dungeon.beaten}
+                              onChange={e => toggleDungeonBeaten(player.id, e.target.checked)}
+                              className="accent-teal w-4 h-4"
+                            />
+                            <span className="text-sm font-body text-parchment/80">Dungeon Beaten</span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Step 1 footer */}
+          <div className="pt-6 pb-2 animate-fade-up delay-4">
             <button
               type="button"
-              onClick={() => setShowAddPlayer(true)}
-              className="p-3 rounded-lg border border-dashed border-teal/30 text-teal-light/70 hover:border-teal hover:text-teal-light text-sm font-body transition-colors"
+              className="btn-gold w-full"
+              onClick={() => {
+                setStep1Attempted(true)
+                if (!step1HasErrors) setStep(2)
+              }}
             >
-              + Add Player
+              Continue to Highscores &#8594;
             </button>
+            {step1Attempted && step1HasErrors && (
+              <ul className="mt-3 space-y-1">
+                {Object.values(step1Errors).filter(Boolean).map((msg, i) => (
+                  <li key={i} className="text-danger text-xs font-body flex items-center gap-1.5">
+                    <span className="text-danger/60">&#8212;</span> {msg}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
-          {validationErrors.players && (
-            <p className="text-danger text-sm mt-2 font-body">{validationErrors.players}</p>
-          )}
-          {showAddPlayer && (
-            <div className="mt-4">
-              <div className="space-y-2">
-                <input
-                  className="input-field w-full"
-                  placeholder="New player name"
-                  value={newPlayerName}
-                  onChange={e => setNewPlayerName(e.target.value)}
-                  onKeyDown={e => { if (e.key === 'Enter') handleAddPlayerInline() }}
-                  autoFocus
-                />
-                <div className="flex gap-2 justify-end">
-                  <button
-                    type="button"
-                    className="btn-outline text-sm"
-                    onClick={() => { setShowAddPlayer(false); setNewPlayerName(''); addPlayer.reset() }}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    className="btn-gold text-sm"
-                    onClick={handleAddPlayerInline}
-                    disabled={!newPlayerName.trim() || addPlayer.isPending}
-                  >
-                    {addPlayer.isPending ? 'Adding...' : 'Add'}
-                  </button>
-                </div>
+        </div>
+      )}
+
+      {/* ── STEP 2: Highscores ── */}
+      {step === 2 && (
+        <div className="animate-fade-up">
+          {/* Header */}
+          <div className="mb-8">
+            <div className="flex items-end justify-between">
+              <div>
+                <h2 className="font-heading text-xl text-gold tracking-wide">Records &amp; Highscores</h2>
+                <p className="text-muted text-sm mt-1 font-body">
+                  Multiple players can share a record. All categories are optional.
+                </p>
               </div>
-              {addPlayer.error && (
-                <p className="text-danger text-xs font-body mt-2">{addPlayer.error.message}</p>
+              {totalHighscoreEntries > 0 && (
+                <div className="flex items-center gap-2 bg-gold/10 border border-gold/20 px-3 py-1.5 rounded-full flex-shrink-0 ml-4">
+                  <span className="text-gold font-heading text-sm">{totalHighscoreEntries}</span>
+                  <span className="text-gold/70 text-xs font-body">
+                    record{totalHighscoreEntries !== 1 ? 's' : ''}
+                  </span>
+                </div>
               )}
             </div>
-          )}
-        </section>
+            <div className="ornament-divider mt-4">
+              <span className="text-gold-dim">&#9670;</span>
+            </div>
+          </div>
 
-        {/* ── Per Player Data ── */}
-        {selectedPlayers.length > 0 && (
-          <section className="animate-fade-up delay-3">
-            <SectionHeader title="Player Details" subtitle="Characters, deaths, and the champion" />
-            <div className="space-y-6">
-              {selectedPlayers.map(player => {
-                const data = form.playerData[player.id]
-                if (!data) return null
-                return (
-                  <div key={player.id} className="bg-surface border border-gold-dim/15 rounded-xl p-5">
-                    <div className="flex items-center justify-between mb-4">
-                      <h3 className="font-heading text-lg text-parchment tracking-wide">{player.name}</h3>
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={data.is_winner}
-                          onChange={() => toggleWinner(player.id)}
-                          className="accent-gold w-4 h-4"
-                        />
-                        <span className={`text-sm font-body ${data.is_winner ? 'text-gold' : 'text-muted'}`}>
-                          Winner
+          {/* Category cards */}
+          <div className="space-y-3 mb-8">
+            {HIGHSCORE_CATEGORIES.map((cat, i) => {
+              const entries = form.highscores[cat.key] || []
+              const hasEntries = entries.length > 0
+              return (
+                <div
+                  key={cat.key}
+                  className={[
+                    'rounded-xl border transition-all duration-300',
+                    highscoreDuplicates[cat.key] || highscoreMissingPlayer[cat.key]
+                      ? 'border-danger/50 bg-surface'
+                      : hasEntries
+                        ? 'border-gold/30 bg-gradient-to-r from-gold/5 to-transparent shadow-[0_0_24px_rgba(201,168,76,0.07)]'
+                        : 'border-gold-dim/15 bg-surface',
+                  ].join(' ')}
+                >
+                  <div className="p-4">
+                    {/* Category header row */}
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3 min-w-0">
+                        <span className={`text-xs font-heading tabular-nums flex-shrink-0 ${hasEntries ? 'text-gold' : 'text-muted'}`}>
+                          {String(i + 1).padStart(2, '0')}
                         </span>
-                      </label>
+                        <h3 className={`font-heading text-sm tracking-wide truncate ${hasEntries ? 'text-parchment' : 'text-parchment/60'}`}>
+                          {cat.label}
+                        </h3>
+                        {hasEntries && (
+                          <span className="flex-shrink-0 text-xs bg-gold/20 text-gold px-2 py-0.5 rounded-full font-body">
+                            {entries.length}
+                          </span>
+                        )}
+                        {cat.gameLevel && (
+                          <span className="flex-shrink-0 text-xs bg-teal/10 text-teal-light px-2 py-0.5 rounded-full font-body">
+                            game
+                          </span>
+                        )}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => addHighscoreEntry(cat.key)}
+                        className="flex-shrink-0 ml-3 text-xs font-body text-teal-light hover:text-teal border border-teal/30 hover:border-teal/60 hover:bg-teal/5 px-2.5 py-1 rounded-md transition-colors"
+                      >
+                        + Add
+                      </button>
                     </div>
 
-                    {/* Characters played */}
-                    <div className="mb-4">
-                      <label className="block text-sm font-body text-parchment/70 mb-2">Characters Played (in order)</label>
-                      <div className="flex flex-wrap gap-2 mb-2">
-                        {data.characters_played.map((char, idx) => (
-                          <span
+                    {highscoreDuplicates[cat.key] && (
+                      <p className="text-danger text-xs font-body mt-2">A player can only appear once per category</p>
+                    )}
+                    {highscoreMissingPlayer[cat.key] && (
+                      <p className="text-danger text-xs font-body mt-2">Select a player for every entry</p>
+                    )}
+
+                    {/* Entries */}
+                    {entries.length > 0 && (
+                      <div className="space-y-2 mt-3 pt-3 border-t border-gold-dim/10">
+                        {entries.map((entry, idx) => (
+                          <div
                             key={idx}
-                            className="inline-flex items-center gap-1.5 bg-elevated px-3 py-1 rounded-full text-sm font-body text-parchment/80"
+                            className={`grid gap-2 items-center animate-fade-in ${cat.gameLevel ? 'grid-cols-[1fr_2rem]' : 'grid-cols-[3fr_7fr_2rem]'}`}
                           >
-                            <span className="text-gold-dim text-xs">{idx + 1}.</span>
-                            {char}
+                            {!cat.gameLevel && (
+                              <select
+                                className="input-field text-sm min-w-0"
+                                value={entry.player_id}
+                                onChange={e => updateHighscoreEntry(cat.key, idx, 'player_id', e.target.value)}
+                              >
+                                <option value="">Player...</option>
+                                {selectedPlayers.map(p => (
+                                  <option key={p.id} value={p.id}>{p.name}</option>
+                                ))}
+                              </select>
+                            )}
+                            <input
+                              type="number"
+                              min="0"
+                              className="input-field text-sm min-w-0"
+                              placeholder="Value"
+                              value={entry.value}
+                              onChange={e => updateHighscoreEntry(cat.key, idx, 'value', e.target.value)}
+                            />
                             <button
                               type="button"
-                              onClick={() => removeCharacter(player.id, idx)}
-                              className="text-muted hover:text-danger ml-0.5 transition-colors"
+                              onClick={() => removeHighscoreEntry(cat.key, idx)}
+                              className="text-lg leading-none text-muted hover:text-danger transition-colors p-1 hover:bg-danger/10 rounded-md justify-self-center"
                             >
                               &times;
                             </button>
-                          </span>
+                          </div>
                         ))}
-                      </div>
-                      <select
-                        className="input-field text-sm"
-                        value=""
-                        onChange={e => addCharacter(player.id, e.target.value)}
-                      >
-                        <option value="">Add a character...</option>
-                        {Object.entries(charactersByExpansion).map(([exp, chars]) => (
-                          <optgroup key={exp} label={exp.replace('_', ' ')}>
-                            {chars.map(c => (
-                              <option key={c.id} value={c.name}>{c.name}</option>
-                            ))}
-                          </optgroup>
-                        ))}
-                      </select>
-                    </div>
-
-                    {/* Deaths */}
-                    <div>
-                      <label className="block text-sm font-body text-parchment/70 mb-1.5">Total Deaths</label>
-                      <input
-                        type="number"
-                        min="0"
-                        className="input-field w-24"
-                        value={data.total_deaths}
-                        onChange={e => updatePlayerData(player.id, 'total_deaths', parseInt(e.target.value) || 0)}
-                      />
-                    </div>
-
-                    {/* Winning character override */}
-                    {data.is_winner && (
-                      <div className="mt-4 p-3 bg-gold/5 border border-gold/20 rounded-lg">
-                        <label className="block text-sm font-body text-gold/80 mb-1.5">Winning Character</label>
-                        <select
-                          className="input-field text-sm"
-                          value={data.winning_character || ''}
-                          onChange={e => updatePlayerData(player.id, 'winning_character', e.target.value)}
-                        >
-                          <option value="">Select...</option>
-                          {data.characters_played.map((char, idx) => (
-                            <option key={idx} value={char}>{char}</option>
-                          ))}
-                        </select>
                       </div>
                     )}
                   </div>
-                )
-              })}
-            </div>
-          </section>
-        )}
-
-        {/* ── Highscores ── */}
-        <section className="animate-fade-up delay-4">
-          <SectionHeader title="Highscores" subtitle="Notable achievements this game (all optional)" />
-          <div className="space-y-4">
-            {HIGHSCORE_CATEGORIES.map(cat => (
-              <div key={cat.key} className="bg-surface border border-gold-dim/15 rounded-xl p-4">
-                <label className="block text-sm font-heading text-parchment/80 tracking-wide mb-3">{cat.label}</label>
-                {cat.gameLevel ? (
-                  <input
-                    type="number"
-                    min="0"
-                    className="input-field text-sm"
-                    placeholder="Value"
-                    value={form.highscores[cat.key]?.value || ''}
-                    onChange={e => updateHighscore(cat.key, 'value', e.target.value)}
-                  />
-                ) : (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <select
-                      className="input-field text-sm"
-                      value={form.highscores[cat.key]?.player_id || ''}
-                      onChange={e => updateHighscore(cat.key, 'player_id', e.target.value)}
-                    >
-                      <option value="">Player...</option>
-                      {selectedPlayers.map(p => (
-                        <option key={p.id} value={p.id}>{p.name}</option>
-                      ))}
-                    </select>
-                    <input
-                      type="number"
-                      min="0"
-                      className="input-field text-sm"
-                      placeholder="Value"
-                      value={form.highscores[cat.key]?.value || ''}
-                      onChange={e => updateHighscore(cat.key, 'value', e.target.value)}
-                    />
-                  </div>
-                )}
-              </div>
-            ))}
+                </div>
+              )
+            })}
           </div>
-        </section>
 
-        {/* ── Expansion Events ── */}
-        {selectedPlayers.length > 0 && (
-          <section className="animate-fade-up delay-5">
-            <SectionHeader title="Expansion Events" subtitle="Per-player woodland paths and dungeon runs" />
-            <div className="space-y-4">
-              {selectedPlayers.map(player => {
-                const events = form.expansionEvents[player.id] ?? emptyPlayerEvents()
-                return (
-                  <div key={player.id} className="bg-surface border border-gold-dim/15 rounded-xl p-5">
-                    <h3 className="font-heading text-lg text-parchment tracking-wide mb-4">{player.name}</h3>
-
-                    <div className="mb-4">
-                      <h4 className="font-heading text-xs text-teal-light tracking-wide uppercase mb-2">Woodland — Paths Completed</h4>
-                      <div className="flex flex-wrap gap-2">
-                        {WOODLAND_PATHS.map(path => {
-                          const selected = events.woodland.paths_completed.includes(path)
-                          return (
-                            <button
-                              key={path}
-                              type="button"
-                              onClick={() => toggleWoodlandPath(player.id, path)}
-                              className={`px-3 py-1.5 rounded-full text-sm font-body border transition-colors ${
-                                selected
-                                  ? 'border-teal bg-teal/15 text-teal-light'
-                                  : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
-                              }`}
-                            >
-                              {path}
-                            </button>
-                          )
-                        })}
-                      </div>
-                    </div>
-
-                    <div>
-                      <h4 className="font-heading text-xs text-teal-light tracking-wide uppercase mb-2">Dungeon</h4>
-                      <label className="flex items-center gap-3 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={events.dungeon.beaten}
-                          onChange={e => toggleDungeonBeaten(player.id, e.target.checked)}
-                          className="accent-teal w-4 h-4"
-                        />
-                        <span className="text-sm font-body text-parchment/80">Dungeon Beaten</span>
-                      </label>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
-          </section>
-        )}
-
-        {/* ── Review & Submit ── */}
-        <section className="animate-fade-up delay-6">
-          <SectionHeader title="Review & Submit" />
-          <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 space-y-4">
-            {/* Summary */}
+          {/* Review summary */}
+          <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 mb-6">
+            <h3 className="font-heading text-base text-parchment tracking-wide mb-4">Summary</h3>
             <div className="grid grid-cols-2 gap-y-3 gap-x-6 text-sm font-body">
               <span className="text-muted">Date</span>
               <span className="text-parchment">{form.date || '—'}</span>
@@ -572,16 +763,8 @@ export default function LogGame({ initialData, isEditing, gameId }) {
               </span>
             </div>
 
-            {form.notes && (
-              <div className="text-sm font-body">
-                <span className="text-muted">Notes: </span>
-                <span className="text-parchment/80 italic">{form.notes}</span>
-              </div>
-            )}
-
-            {/* Player details summary */}
             {selectedPlayers.length > 0 && (
-              <div>
+              <>
                 <div className="ornament-divider my-4">
                   <span className="text-gold-dim text-xs">&#9670;</span>
                 </div>
@@ -590,48 +773,88 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                     const data = form.playerData[player.id]
                     if (!data) return null
                     return (
-                      <div key={player.id} className="flex items-start gap-3 text-sm font-body py-1.5">
+                      <div key={player.id} className="flex items-start gap-3 text-sm font-body py-1">
                         <span className={`font-medium min-w-[80px] ${data.is_winner ? 'text-gold' : 'text-parchment'}`}>
                           {player.name}{data.is_winner ? ' *' : ''}
                         </span>
                         <span className="text-parchment/60">
-                          {data.characters_played.length > 0 ? data.characters_played.join(' → ') : 'No characters'}
-                          {' · '}{data.total_deaths} death{data.total_deaths !== 1 ? 's' : ''}
+                          {data.characters_played.length > 0 ? data.characters_played.join(' \u2192 ') : 'No characters'}
+                          {' \u00b7 '}{data.total_deaths} death{data.total_deaths !== 1 ? 's' : ''}
                         </span>
                       </div>
                     )
                   })}
                 </div>
-              </div>
+              </>
             )}
 
-            {submitError && (
-              <p className="text-danger text-sm font-body">{submitError.message}</p>
+            {totalHighscoreEntries > 0 && (
+              <>
+                <div className="ornament-divider my-4">
+                  <span className="text-gold-dim text-xs">&#9670;</span>
+                </div>
+                <p className="text-xs font-heading text-muted uppercase tracking-widest mb-2">Highscores</p>
+                <div className="space-y-1">
+                  {HIGHSCORE_CATEGORIES.map(cat => {
+                    const entries = (form.highscores[cat.key] || []).filter(e => e.value !== '' && e.value != null && (cat.gameLevel || e.player_id))
+                    if (entries.length === 0) return null
+                    return (
+                      <div key={cat.key} className="flex items-start gap-2 text-sm font-body">
+                        <span className="text-muted min-w-[140px]">{cat.label}</span>
+                        <span className="text-parchment/80">
+                          {entries.map(e => {
+                            const name = cat.gameLevel ? null : allPlayers.find(p => p.id === e.player_id)?.name
+                            return name ? `${name} (${e.value})` : e.value
+                          }).join(', ')}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+              </>
             )}
 
-            <div className="pt-4 flex gap-3">
+            {form.notes && (
+              <p className="text-sm font-body mt-3 text-parchment/60 italic">
+                &ldquo;{form.notes}&rdquo;
+              </p>
+            )}
+          </div>
+
+          {submitError && (
+            <p className="text-danger text-sm font-body mb-4">{submitError.message}</p>
+          )}
+
+          {/* Step 2 footer */}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              className="btn-outline"
+              onClick={() => setStep(1)}
+            >
+              &#8592; Back
+            </button>
+            <button
+              type="button"
+              className="btn-gold flex-1"
+              onClick={handleSubmit}
+              disabled={submitting}
+            >
+              {submitting ? 'Saving...' : isEditing ? 'Save Changes' : 'Submit Game'}
+            </button>
+            {isEditing && (
               <button
                 type="button"
-                className="btn-gold"
-                onClick={handleSubmit}
-                disabled={submitting || hasErrors}
+                className="btn-danger"
+                onClick={handleDelete}
+                disabled={deleteGame.isPending}
               >
-                {submitting ? 'Saving...' : isEditing ? 'Save Changes' : 'Submit Game'}
+                {deleteGame.isPending ? 'Deleting...' : 'Delete'}
               </button>
-              {isEditing && (
-                <button
-                  type="button"
-                  className="btn-danger"
-                  onClick={handleDelete}
-                  disabled={deleteGame.isPending}
-                >
-                  {deleteGame.isPending ? 'Deleting...' : 'Delete Game'}
-                </button>
-              )}
-            </div>
+            )}
           </div>
-        </section>
-      </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/supabase/migrations/20260413000001_add_highscore_categories.sql
+++ b/supabase/migrations/20260413000001_add_highscore_categories.sql
@@ -1,6 +1,10 @@
--- Add new highscore categories
+-- Expand allowed highscore categories.
+-- Replaces the original 4-value constraint with the full set.
+-- Migrate legacy 'most_coins' rows to 'most_gold' before re-adding the constraint.
 alter table game_highscores
   drop constraint game_highscores_category_check;
+
+update game_highscores set category = 'most_gold' where category = 'most_coins';
 
 alter table game_highscores
   add constraint game_highscores_category_check

--- a/supabase/migrations/20260413000002_replace_characters.sql
+++ b/supabase/migrations/20260413000002_replace_characters.sql
@@ -1,0 +1,94 @@
+-- Replace all characters with the definitive list.
+-- Expansion values are now human-readable (e.g. 'The Reaper') because they are
+-- displayed directly as <optgroup> labels in the Log Game UI.
+-- characters_played in game_players stores character names as plain text (no FK),
+-- so truncating this table has no cascade impact on game data.
+
+truncate table characters;
+
+insert into characters (name, expansion) values
+  -- Base Game
+  ('Assassin',          'Base Game'),
+  ('Druid',             'Base Game'),
+  ('Dwarf',             'Base Game'),
+  ('Elf',               'Base Game'),
+  ('Ghoul',             'Base Game'),
+  ('Minstrel',          'Base Game'),
+  ('Monk',              'Base Game'),
+  ('Priest',            'Base Game'),
+  ('Prophetess',        'Base Game'),
+  ('Sorceress',         'Base Game'),
+  ('Thief',             'Base Game'),
+  ('Troll',             'Base Game'),
+  ('Warrior',           'Base Game'),
+  ('Wizard',            'Base Game'),
+  -- The Reaper
+  ('Sage',              'The Reaper'),
+  ('Merchant',          'The Reaper'),
+  ('Dark Cultist',      'The Reaper'),
+  ('Knight',            'The Reaper'),
+
+  -- The Frostmarch
+  ('Leprechaun',        'The Frostmarch'),
+  ('Necromancer',       'The Frostmarch'),
+  ('Ogre Chieftain',    'The Frostmarch'),
+  ('Warlock',           'The Frostmarch'),
+
+  -- The Dragon
+  ('Minotaur',          'The Dragon'),
+  ('Dragon Hunter',     'The Dragon'),
+  ('Conjurer',          'The Dragon'),
+  ('Fire Wizard',       'The Dragon'),
+  ('Dragon Priestess',  'The Dragon'),
+  ('Dragon Rider',      'The Dragon'),
+
+  -- The Woodland
+  ('Spider Queen',      'The Woodland'),
+  ('Totem Warrior',     'The Woodland'),
+  ('Scout',             'The Woodland'),
+  ('Leywalker',         'The Woodland'),
+  ('Ancient Oak',       'The Woodland'),
+
+  -- The City
+  ('Cat Burglar',       'The City'),
+  ('Elementalist',      'The City'),
+  ('Tinkerer',          'The City'),
+  ('Tavern Maid',       'The City'),
+  ('Bounty Hunter',     'The City'),
+  ('Spy',               'The City'),
+
+  -- The Harbinger
+  ('Ascendant Divine',  'The Harbinger'),
+  ('Possessed',         'The Harbinger'),
+  ('Celestial',         'The Harbinger'),
+
+  -- The Firelands
+  ('Dervish',           'The Firelands'),
+  ('Jin Blooded',       'The Firelands'),
+  ('Warlord',           'The Firelands'),
+  ('Nomad',             'The Firelands'),
+
+  -- The Cataclysm
+  ('Black Knight',      'The Cataclysm'),
+  ('Mutant',            'The Cataclysm'),
+  ('Scavenger',         'The Cataclysm'),
+  ('Arcane Scion',      'The Cataclysm'),
+  ('Barbarian',         'The Cataclysm'),
+
+  -- The Dungeon
+  ('Philosopher',       'The Dungeon'),
+  ('Swashbuckler',      'The Dungeon'),
+  ('Amazon',            'The Dungeon'),
+  ('Gladiator',         'The Dungeon'),
+  ('Gypsy',             'The Dungeon'),
+
+  -- The Sacred Pool
+  ('Chivalric Knight',  'The Sacred Pool'),
+  ('Cleric',            'The Sacred Pool'),
+  ('Dread Knight',      'The Sacred Pool'),
+  ('Magus',             'The Sacred Pool'),
+
+  -- The Blood Moon
+  ('Doomsayer',         'The Blood Moon'),
+  ('Grave Robber',      'The Blood Moon'),
+  ('Vampire Hunter',    'The Blood Moon');


### PR DESCRIPTION
## Summary
Adds new highscore categories to the log game wizard, replaces the character seed data with a definitive list tied to the correct expansions, and orders expansion groups in the character picker by release order.

## Changes
- Add highscore categories migration and update `useHighscoreRecords`, `gameWrites`, and `HighscoresBoard` to support them
- Replace character seed data with definitive list across all expansions (Base Game → The Blood Moon)
- Order expansion `<optgroup>` sections in the character picker by release order instead of insertion order
- Clean up highscore category label copy (removed parenthetical qualifiers)