### PR TITLE
feat(stats): add stats screen with characters, endings, expansions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import HighscoresBoard from './pages/HighscoresBoard'
 import GameHistory from './pages/GameHistory'
 import GameDetail from './pages/GameDetail'
 import Players from './pages/Players'
+import Stats from './pages/Stats'
 
 const queryClient = new QueryClient()
 
@@ -26,6 +27,7 @@ export default function App() {
             <Route path="/history" element={<GameHistory />} />
             <Route path="/games/:id" element={<GameDetail />} />
             <Route path="/players" element={<Players />} />
+            <Route path="/stats" element={<Stats />} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -6,6 +6,7 @@ const NAV_LINKS = [
   { to: '/log', label: 'Log Game' },
   { to: '/leaderboard', label: 'Leaderboard' },
   { to: '/highscores', label: 'Highscores' },
+  { to: '/stats', label: 'Stats' },
   { to: '/history', label: 'History' },
   { to: '/players', label: 'Players' },
 ]

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -12,6 +12,7 @@ export function useGame(id) {
           id,
           date,
           notes,
+          optional_expansions,
           created_at,
           updated_at,
           ending:endings ( id, name, expansion ),
@@ -34,6 +35,7 @@ export function useGame(id) {
             expansion,
             event_type,
             detail,
+            character,
             player:players ( id, name )
           )
         `)
@@ -44,6 +46,7 @@ export function useGame(id) {
         id: data.id,
         date: data.date,
         notes: data.notes,
+        optional_expansions: data.optional_expansions ?? [],
         createdAt: data.created_at,
         updatedAt: data.updated_at,
         ending: data.ending,

--- a/src/hooks/useLogGame.js
+++ b/src/hooks/useLogGame.js
@@ -12,6 +12,7 @@ export function useLogGame() {
           date: formState.date,
           ending_id: formState.ending_id,
           notes: formState.notes || null,
+          optional_expansions: formState.optional_expansions ?? [],
         })
         .select('id')
         .single()
@@ -30,6 +31,7 @@ export function useLogGame() {
       queryClient.invalidateQueries({ queryKey: ['games'] })
       queryClient.invalidateQueries({ queryKey: ['leaderboardStats'] })
       queryClient.invalidateQueries({ queryKey: ['highscoreRecords'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
     },
   })
 }

--- a/src/hooks/useStatsData.js
+++ b/src/hooks/useStatsData.js
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+
+export function useStatsData() {
+  return useQuery({
+    queryKey: ['stats'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('games')
+        .select(`
+          id,
+          optional_expansions,
+          ending:endings ( id, name, expansion ),
+          players:game_players (
+            id,
+            characters_played,
+            total_deaths,
+            is_winner,
+            winning_character,
+            player:players ( id, name )
+          ),
+          expansion_events:game_expansion_events (
+            id,
+            expansion,
+            event_type,
+            detail,
+            character,
+            player:players ( id, name )
+          )
+        `)
+      if (error) throw error
+      return data ?? []
+    },
+  })
+}

--- a/src/hooks/useUpdateGame.js
+++ b/src/hooks/useUpdateGame.js
@@ -12,6 +12,7 @@ export function useUpdateGame() {
           date: formState.date,
           ending_id: formState.ending_id,
           notes: formState.notes || null,
+          optional_expansions: formState.optional_expansions ?? [],
           updated_at: new Date().toISOString(),
         })
         .eq('id', gameId)
@@ -27,6 +28,7 @@ export function useUpdateGame() {
       queryClient.invalidateQueries({ queryKey: ['game', gameId] })
       queryClient.invalidateQueries({ queryKey: ['leaderboardStats'] })
       queryClient.invalidateQueries({ queryKey: ['highscoreRecords'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
     },
   })
 }

--- a/src/lib/gameWrites.js
+++ b/src/lib/gameWrites.js
@@ -44,24 +44,33 @@ export function buildExpansionEventRows(gameId, formState) {
     const perPlayer = events[playerId]
     if (!perPlayer) continue
 
-    for (const path of perPlayer.woodland?.paths_completed ?? []) {
+    const playedChars = formState.playerData?.[playerId]?.characters_played ?? []
+    const fallbackChar = playedChars.length === 1 ? playedChars[0] : null
+
+    for (const entry of perPlayer.woodland?.paths_completed ?? []) {
+      const path = typeof entry === 'string' ? entry : entry?.path
       if (!path) continue
+      const character = (typeof entry === 'object' && entry?.character) || fallbackChar || null
       rows.push({
         game_id: gameId,
         player_id: playerId,
         expansion: 'woodland',
         event_type: 'path_completed',
         detail: path,
+        character,
       })
     }
 
-    if (perPlayer.dungeon?.beaten) {
+    const dungeon = perPlayer.dungeon
+    if (dungeon?.beaten) {
+      const character = dungeon.character || fallbackChar || null
       rows.push({
         game_id: gameId,
         player_id: playerId,
         expansion: 'dungeon',
         event_type: 'dungeon_beaten',
         detail: null,
+        character,
       })
     }
   }

--- a/src/lib/statsAggregations.js
+++ b/src/lib/statsAggregations.js
@@ -1,0 +1,207 @@
+// ============================================================
+// Pure stats aggregations for the Stats screen.
+// All functions take the raw games payload from useStatsData
+// (already filtered by the top-level optional-expansions filter)
+// and return table-ready rows.
+// ============================================================
+
+export const OPTIONAL_EXPANSION_FILTERS = [
+  { key: 'all', label: 'All Games' },
+  { key: 'normal', label: 'Normal (no optional)' },
+  { key: 'dragon', label: 'With Dragon only' },
+  { key: 'harbinger', label: 'With Harbinger only' },
+  { key: 'both', label: 'With Dragon + Harbinger' },
+]
+
+export function filterGamesByOptionalExpansions(games, filterKey) {
+  if (!filterKey || filterKey === 'all') return games
+  return games.filter((g) => {
+    const arr = g.optional_expansions ?? []
+    const hasDragon = arr.includes('dragon')
+    const hasHarbinger = arr.includes('harbinger')
+    switch (filterKey) {
+      case 'normal':
+        return !hasDragon && !hasHarbinger
+      case 'dragon':
+        return hasDragon && !hasHarbinger
+      case 'harbinger':
+        return hasHarbinger && !hasDragon
+      case 'both':
+        return hasDragon && hasHarbinger
+      default:
+        return true
+    }
+  })
+}
+
+// ── Characters ──────────────────────────────────────────────
+// Each appearance in characters_played counts as 1 game for that
+// character. Deaths: first `total_deaths` characters in the ordered
+// array are deaths, the rest are survivors. Wins: matches
+// winning_character.
+export function computeCharacterStats(games, allCharacters) {
+  const stats = new Map()
+  const ensure = (name) => {
+    if (!stats.has(name)) {
+      stats.set(name, {
+        character: name,
+        expansion: null,
+        games: 0,
+        wins: 0,
+        deaths: 0,
+      })
+    }
+    return stats.get(name)
+  }
+
+  for (const game of games) {
+    for (const gp of game.players ?? []) {
+      const chars = gp.characters_played ?? []
+      const deaths = Math.min(gp.total_deaths ?? 0, chars.length)
+      chars.forEach((char, idx) => {
+        const row = ensure(char)
+        row.games += 1
+        if (idx < deaths) row.deaths += 1
+      })
+      if (gp.is_winner && gp.winning_character) {
+        ensure(gp.winning_character).wins += 1
+      }
+    }
+  }
+
+  const expansionByName = new Map(
+    (allCharacters ?? []).map((c) => [c.name, c.expansion]),
+  )
+  const rows = Array.from(stats.values()).map((row) => ({
+    ...row,
+    expansion: expansionByName.get(row.character) ?? 'NA',
+    winRate: row.games > 0 ? row.wins / row.games : 0,
+    deathRate: row.games > 0 ? row.deaths / row.games : 0,
+  }))
+
+  // Characters that exist in seed but were never played get a zero row
+  for (const c of allCharacters ?? []) {
+    if (!stats.has(c.name)) {
+      rows.push({
+        character: c.name,
+        expansion: c.expansion,
+        games: 0,
+        wins: 0,
+        deaths: 0,
+        winRate: 0,
+        deathRate: 0,
+      })
+    }
+  }
+
+  return rows
+}
+
+// ── Endings ─────────────────────────────────────────────────
+// For each ending: times triggered, % of games, player win rate,
+// talisman (no-winner) rate, top winning character.
+export function computeEndingStats(games) {
+  const stats = new Map()
+  const totalGames = games.length
+
+  for (const game of games) {
+    const ending = game.ending
+    if (!ending) continue
+    const id = ending.id
+    if (!stats.has(id)) {
+      stats.set(id, {
+        id,
+        name: ending.name,
+        expansion: ending.expansion,
+        times: 0,
+        playerWins: 0,
+        talismanWins: 0,
+        winningCharCounts: new Map(),
+      })
+    }
+    const row = stats.get(id)
+    row.times += 1
+    const winners = (game.players ?? []).filter((gp) => gp.is_winner)
+    if (winners.length > 0) {
+      row.playerWins += 1
+      for (const w of winners) {
+        if (w.winning_character) {
+          row.winningCharCounts.set(
+            w.winning_character,
+            (row.winningCharCounts.get(w.winning_character) ?? 0) + 1,
+          )
+        }
+      }
+    } else {
+      row.talismanWins += 1
+    }
+  }
+
+  return Array.from(stats.values()).map((row) => {
+    let topChar = null
+    let topCount = 0
+    for (const [char, count] of row.winningCharCounts.entries()) {
+      if (count > topCount) {
+        topChar = char
+        topCount = count
+      }
+    }
+    return {
+      id: row.id,
+      name: row.name,
+      expansion: row.expansion,
+      times: row.times,
+      pctOfGames: totalGames > 0 ? row.times / totalGames : 0,
+      playerWinRate: row.times > 0 ? row.playerWins / row.times : 0,
+      talismanWinRate: row.times > 0 ? row.talismanWins / row.times : 0,
+      topWinningCharacter: topChar ? `${topChar} (${topCount})` : 'NA',
+    }
+  })
+}
+
+// ── Expansion events ────────────────────────────────────────
+// Per-character aggregation of dungeon_beaten and path_completed,
+// plus per-character totals of paths (across all path types) and
+// global totals for the filtered game set.
+// Events with no character attribution are grouped as "Unknown".
+export function computeExpansionEventStats(games) {
+  const dungeons = new Map()     // character -> { character, count }
+  const paths = new Map()        // `${character}::${path}` -> { character, path, count }
+  const pathsTotals = new Map()  // character -> { character, count }
+  const pathsByPath = new Map()  // path -> { path, count }
+  let totalDungeons = 0
+  let totalPaths = 0
+
+  for (const game of games) {
+    for (const ev of game.expansion_events ?? []) {
+      const character = ev.character || 'Unknown'
+      if (ev.event_type === 'dungeon_beaten') {
+        const row = dungeons.get(character) ?? { character, count: 0 }
+        row.count += 1
+        dungeons.set(character, row)
+        totalDungeons += 1
+      } else if (ev.event_type === 'path_completed') {
+        const path = ev.detail || 'NA'
+        const key = `${character}::${path}`
+        const row = paths.get(key) ?? { character, path, count: 0 }
+        row.count += 1
+        paths.set(key, row)
+        const totalRow = pathsTotals.get(character) ?? { character, count: 0 }
+        totalRow.count += 1
+        pathsTotals.set(character, totalRow)
+        const pathRow = pathsByPath.get(path) ?? { path, count: 0 }
+        pathRow.count += 1
+        pathsByPath.set(path, pathRow)
+        totalPaths += 1
+      }
+    }
+  }
+
+  return {
+    dungeons: Array.from(dungeons.values()),
+    paths: Array.from(paths.values()),
+    pathsTotals: Array.from(pathsTotals.values()),
+    pathsByPath: Array.from(pathsByPath.values()),
+    totals: { dungeons: totalDungeons, paths: totalPaths },
+  }
+}

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -19,6 +19,7 @@ export default function EditGame() {
     date: game.date,
     ending_id: game.ending?.id ?? '',
     notes: game.notes || '',
+    optional_expansions: game.optional_expansions ?? [],
     players: game.players.map(p => p.player.id),
     playerData: game.players.reduce((acc, p) => {
       acc[p.player.id] = {
@@ -36,17 +37,19 @@ export default function EditGame() {
     }, {}),
     expansionEvents: game.players.reduce((acc, gp) => {
       const pid = gp.player.id
+      const dungeonEvent = game.expansion_events.find(
+        e => e.player?.id === pid && e.event_type === 'dungeon_beaten',
+      )
       acc[pid] = {
         woodland: {
           paths_completed: game.expansion_events
             .filter(e => e.player?.id === pid && e.expansion === 'woodland')
-            .map(e => e.detail)
-            .filter(Boolean),
+            .map(e => ({ path: e.detail, character: e.character || null }))
+            .filter(e => e.path),
         },
         dungeon: {
-          beaten: game.expansion_events.some(
-            e => e.player?.id === pid && e.event_type === 'dungeon_beaten',
-          ),
+          beaten: !!dungeonEvent,
+          character: dungeonEvent?.character || null,
         },
       }
       return acc

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -94,19 +94,21 @@ export default function HighscoresBoard() {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {records.map((record, i) => {
           const empty = record.entries.length === 0
-          const [gold, ...rest] = record.entries
+          const [gold] = record.entries
           return (
             <div
               key={record.category}
               className={`card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 animate-fade-up delay-${i + 2}`}
             >
-              <div className="flex items-start justify-between mb-1">
-                <div className="text-gold/50">{CATEGORY_ICONS[record.category]}</div>
-                <span className={`font-display text-3xl tracking-wider leading-none ${empty ? 'text-muted/40' : 'text-gold'}`}>
+              <div className="flex items-center justify-between mb-3 gap-3">
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="text-gold/50 shrink-0">{CATEGORY_ICONS[record.category]}</div>
+                  <h3 className="font-heading text-parchment text-xl tracking-wide truncate">{record.label}</h3>
+                </div>
+                <span className={`font-display text-3xl tracking-wider leading-none shrink-0 ${empty ? 'text-muted/40' : 'text-gold'}`}>
                   {empty ? '×' : gold.value}
                 </span>
               </div>
-              <h3 className="font-heading text-parchment text-2xl tracking-wide mb-3">{record.label}</h3>
               {empty && <p className="text-muted text-sm font-body mb-3">No record yet</p>}
 
               {!empty && (

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -34,6 +34,7 @@ const INITIAL_STATE = {
   date: new Date().toISOString().split('T')[0],
   ending_id: '',
   notes: '',
+  optional_expansions: [],
   players: [],
   playerData: {},
   highscores: {},
@@ -42,8 +43,13 @@ const INITIAL_STATE = {
 
 const emptyPlayerEvents = () => ({
   woodland: { paths_completed: [] },
-  dungeon: { beaten: false },
+  dungeon: { beaten: false, character: null },
 })
+
+const OPTIONAL_EXPANSIONS = [
+  { key: 'dragon', label: 'The Dragon' },
+  { key: 'harbinger', label: 'The Harbinger' },
+]
 
 function SectionHeader({ title, subtitle }) {
   return (
@@ -204,7 +210,28 @@ export default function LogGame({ initialData, isEditing, gameId }) {
     setForm(prev => {
       const existing = prev.expansionEvents[playerId] ?? emptyPlayerEvents()
       const current = existing.woodland.paths_completed
-      const updated = current.includes(path) ? current.filter(p => p !== path) : [...current, path]
+      const idx = current.findIndex(e => e.path === path)
+      const playedChars = prev.playerData[playerId]?.characters_played ?? []
+      const fallbackChar = playedChars.length === 1 ? playedChars[0] : null
+      const updated = idx >= 0
+        ? current.filter((_, i) => i !== idx)
+        : [...current, { path, character: fallbackChar }]
+      return {
+        ...prev,
+        expansionEvents: {
+          ...prev.expansionEvents,
+          [playerId]: { ...existing, woodland: { paths_completed: updated } },
+        },
+      }
+    })
+  }
+
+  const setWoodlandPathCharacter = (playerId, path, character) => {
+    setForm(prev => {
+      const existing = prev.expansionEvents[playerId] ?? emptyPlayerEvents()
+      const updated = existing.woodland.paths_completed.map(e =>
+        e.path === path ? { ...e, character: character || null } : e,
+      )
       return {
         ...prev,
         expansionEvents: {
@@ -218,12 +245,47 @@ export default function LogGame({ initialData, isEditing, gameId }) {
   const toggleDungeonBeaten = (playerId, checked) => {
     setForm(prev => {
       const existing = prev.expansionEvents[playerId] ?? emptyPlayerEvents()
+      const playedChars = prev.playerData[playerId]?.characters_played ?? []
+      const fallbackChar = playedChars.length === 1 ? playedChars[0] : null
       return {
         ...prev,
         expansionEvents: {
           ...prev.expansionEvents,
-          [playerId]: { ...existing, dungeon: { beaten: checked } },
+          [playerId]: {
+            ...existing,
+            dungeon: checked
+              ? { beaten: true, character: existing.dungeon.character || fallbackChar }
+              : { beaten: false, character: null },
+          },
         },
+      }
+    })
+  }
+
+  const setDungeonCharacter = (playerId, character) => {
+    setForm(prev => {
+      const existing = prev.expansionEvents[playerId] ?? emptyPlayerEvents()
+      return {
+        ...prev,
+        expansionEvents: {
+          ...prev.expansionEvents,
+          [playerId]: {
+            ...existing,
+            dungeon: { ...existing.dungeon, character: character || null },
+          },
+        },
+      }
+    })
+  }
+
+  const toggleOptionalExpansion = (key) => {
+    setForm(prev => {
+      const current = prev.optional_expansions ?? []
+      return {
+        ...prev,
+        optional_expansions: current.includes(key)
+          ? current.filter(k => k !== key)
+          : [...current, key],
       }
     })
   }
@@ -243,12 +305,23 @@ export default function LogGame({ initialData, isEditing, gameId }) {
   const playersWithNoCharacter = form.players.filter(
     id => !form.playerData[id]?.characters_played?.length,
   )
+  const playersWithInvalidDeaths = form.players.filter(id => {
+    const pd = form.playerData[id]
+    if (!pd) return false
+    const n = pd.characters_played?.length ?? 0
+    if (n === 0) return false
+    const d = Number(pd.total_deaths ?? 0)
+    return d !== n && d !== n - 1
+  })
   const step1Errors = {
     date: !form.date ? 'Date is required' : null,
     ending_id: !form.ending_id ? 'Ending is required' : null,
     players: form.players.length < 2 ? 'Select at least 2 players' : null,
     characters: playersWithNoCharacter.length > 0
       ? 'Every player needs at least one character'
+      : null,
+    deaths: playersWithInvalidDeaths.length > 0
+      ? 'Total deaths must equal characters played or one less'
       : null,
   }
   const step1HasErrors = Object.values(step1Errors).some(Boolean)
@@ -367,6 +440,31 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                 )}
               </div>
               <div>
+                <label className="block text-sm font-body text-parchment/80 mb-1.5">Optional Expansions</label>
+                <div className="flex flex-wrap gap-2">
+                  {OPTIONAL_EXPANSIONS.map(opt => {
+                    const selected = (form.optional_expansions ?? []).includes(opt.key)
+                    return (
+                      <button
+                        key={opt.key}
+                        type="button"
+                        onClick={() => toggleOptionalExpansion(opt.key)}
+                        className={`px-3 py-1.5 rounded-full text-sm font-body border transition-colors ${
+                          selected
+                            ? 'border-gold bg-gold/10 text-gold'
+                            : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
+                        }`}
+                      >
+                        {opt.label}
+                      </button>
+                    )
+                  })}
+                </div>
+                <p className="text-muted text-xs mt-1.5 font-body">
+                  Only check what was actually in play, everything else is assumed on.
+                </p>
+              </div>
+              <div>
                 <label className="block text-sm font-body text-parchment/80 mb-1.5">Notes (optional)</label>
                 <textarea
                   className="input-field min-h-[80px] resize-y"
@@ -476,24 +574,6 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                       {/* Characters played */}
                       <div className="mb-4">
                         <label className="block text-sm font-body text-parchment/70 mb-2">Characters Played (in order)</label>
-                        <div className="flex flex-wrap gap-2 mb-2">
-                          {data.characters_played.map((char, idx) => (
-                            <span
-                              key={idx}
-                              className="inline-flex items-center gap-1.5 bg-elevated px-3 py-1 rounded-full text-sm font-body text-parchment/80"
-                            >
-                              <span className="text-gold-dim text-xs">{idx + 1}.</span>
-                              {char}
-                              <button
-                                type="button"
-                                onClick={() => removeCharacter(player.id, idx)}
-                                className="text-muted hover:text-danger ml-0.5 transition-colors"
-                              >
-                                &times;
-                              </button>
-                            </span>
-                          ))}
-                        </div>
                         <select
                           className="input-field text-sm"
                           value=""
@@ -502,12 +582,32 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                           <option value="">Add a character...</option>
                           {orderedExpansions.map(exp => (
                             <optgroup key={exp} label={exp}>
-                              {chars.map(c => (
+                              {charactersByExpansion[exp].map(c => (
                                 <option key={c.id} value={c.name}>{c.name}</option>
                               ))}
                             </optgroup>
                           ))}
                         </select>
+                        {data.characters_played.length > 0 && (
+                          <div className="flex flex-wrap gap-2 mt-2">
+                            {data.characters_played.map((char, idx) => (
+                              <span
+                                key={idx}
+                                className="inline-flex items-center gap-1.5 bg-elevated px-3 py-1 rounded-full text-sm font-body text-parchment/80"
+                              >
+                                <span className="text-gold-dim text-xs">{idx + 1}.</span>
+                                {char}
+                                <button
+                                  type="button"
+                                  onClick={() => removeCharacter(player.id, idx)}
+                                  className="text-muted hover:text-danger ml-0.5 transition-colors"
+                                >
+                                  &times;
+                                </button>
+                              </span>
+                            ))}
+                          </div>
+                        )}
                         {step1Attempted && playersWithNoCharacter.includes(player.id) && (
                           <p className="text-danger text-xs mt-1.5 font-body">Add at least one character</p>
                         )}
@@ -523,6 +623,11 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                           value={data.total_deaths}
                           onChange={e => updatePlayerData(player.id, 'total_deaths', parseInt(e.target.value) || 0)}
                         />
+                        {step1Attempted && playersWithInvalidDeaths.includes(player.id) && (
+                          <p className="text-danger text-xs mt-1.5 font-body">
+                            Must be {Math.max(0, data.characters_played.length - 1)} or {data.characters_played.length}
+                          </p>
+                        )}
                       </div>
 
                       {/* Winning character override */}
@@ -547,10 +652,11 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                         <p className="text-xs font-heading text-muted uppercase tracking-widest mb-3">Expansion Events</p>
 
                         <div className="mb-3">
-                          <h4 className="font-heading text-xs text-teal-light tracking-wide uppercase mb-2">Woodland — Paths Completed</h4>
-                          <div className="flex flex-wrap gap-2">
+                          <h4 className="font-heading text-xs text-teal-light tracking-wide uppercase mb-2">Woodland, Paths Completed</h4>
+                          <div className="flex flex-wrap gap-2 mb-2">
                             {WOODLAND_PATHS.map(path => {
-                              const selected = events.woodland.paths_completed.includes(path)
+                              const entry = events.woodland.paths_completed.find(e => e.path === path)
+                              const selected = !!entry
                               return (
                                 <button
                                   key={path}
@@ -567,6 +673,25 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                               )
                             })}
                           </div>
+                          {events.woodland.paths_completed.length > 0 && data.characters_played.length > 1 && (
+                            <div className="space-y-1.5 mt-2">
+                              {events.woodland.paths_completed.map(entry => (
+                                <div key={entry.path} className="flex items-center gap-2">
+                                  <span className="text-xs font-body text-muted min-w-[120px]">{entry.path}</span>
+                                  <select
+                                    className="input-field text-xs py-1 flex-1"
+                                    value={entry.character || ''}
+                                    onChange={e => setWoodlandPathCharacter(player.id, entry.path, e.target.value)}
+                                  >
+                                    <option value="">Which character?</option>
+                                    {data.characters_played.map((c, i) => (
+                                      <option key={`${c}-${i}`} value={c}>{c}</option>
+                                    ))}
+                                  </select>
+                                </div>
+                              ))}
+                            </div>
+                          )}
                         </div>
 
                         <div>
@@ -580,6 +705,20 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                             />
                             <span className="text-sm font-body text-parchment/80">Dungeon Beaten</span>
                           </label>
+                          {events.dungeon.beaten && data.characters_played.length > 1 && (
+                            <div className="mt-2">
+                              <select
+                                className="input-field text-xs py-1"
+                                value={events.dungeon.character || ''}
+                                onChange={e => setDungeonCharacter(player.id, e.target.value)}
+                              >
+                                <option value="">Which character?</option>
+                                {data.characters_played.map((c, i) => (
+                                  <option key={`${c}-${i}`} value={c}>{c}</option>
+                                ))}
+                              </select>
+                            </div>
+                          )}
                         </div>
                       </div>
                     </div>
@@ -744,20 +883,20 @@ export default function LogGame({ initialData, isEditing, gameId }) {
             <h3 className="font-heading text-base text-parchment tracking-wide mb-4">Summary</h3>
             <div className="grid grid-cols-2 gap-y-3 gap-x-6 text-sm font-body">
               <span className="text-muted">Date</span>
-              <span className="text-parchment">{form.date || '—'}</span>
+              <span className="text-parchment">{form.date || 'NA'}</span>
               <span className="text-muted">Ending</span>
               <span className="text-parchment">
-                {form.ending_id ? allEndings.find(e => e.id === form.ending_id)?.name : '—'}
+                {form.ending_id ? allEndings.find(e => e.id === form.ending_id)?.name : 'NA'}
               </span>
               <span className="text-muted">Players</span>
               <span className="text-parchment">
-                {selectedPlayers.length > 0 ? selectedPlayers.map(p => p.name).join(', ') : '—'}
+                {selectedPlayers.length > 0 ? selectedPlayers.map(p => p.name).join(', ') : 'NA'}
               </span>
               <span className="text-muted">Winner</span>
               <span className="text-gold">
                 {(() => {
                   const winners = selectedPlayers.filter(p => form.playerData[p.id]?.is_winner)
-                  if (winners.length === 0) return selectedPlayers.length > 0 ? 'Talisman' : '—'
+                  if (winners.length === 0) return selectedPlayers.length > 0 ? 'Talisman' : 'NA'
                   return winners.map(p => p.name).join(', ')
                 })()}
               </span>

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -1,0 +1,344 @@
+import { useMemo, useState } from 'react'
+import { useStatsData } from '../hooks/useStatsData'
+import { useCharacters } from '../hooks/useCharacters'
+import {
+  OPTIONAL_EXPANSION_FILTERS,
+  filterGamesByOptionalExpansions,
+  computeCharacterStats,
+  computeEndingStats,
+  computeExpansionEventStats,
+} from '../lib/statsAggregations'
+
+const TABS = [
+  { key: 'characters', label: 'Characters' },
+  { key: 'endings', label: 'Endings' },
+  { key: 'expansions', label: 'Expansions' },
+]
+
+function SortIcon({ active, direction }) {
+  return (
+    <span className={`inline-block ml-1 text-[10px] transition-opacity ${active ? 'opacity-100' : 'opacity-0 group-hover:opacity-40'}`}>
+      {direction === 'asc' ? '▲' : '▼'}
+    </span>
+  )
+}
+
+function useSort(initialKey, initialDir = 'desc') {
+  const [sortKey, setSortKey] = useState(initialKey)
+  const [sortDir, setSortDir] = useState(initialDir)
+  const toggle = (key) => {
+    if (sortKey === key) setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    else { setSortKey(key); setSortDir('desc') }
+  }
+  const sort = (rows) => [...rows].sort((a, b) => {
+    const aVal = a[sortKey]
+    const bVal = b[sortKey]
+    if (typeof aVal === 'string') return sortDir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
+    return sortDir === 'asc' ? (aVal ?? 0) - (bVal ?? 0) : (bVal ?? 0) - (aVal ?? 0)
+  })
+  return { sortKey, sortDir, toggle, sort }
+}
+
+function StatsTable({ columns, rows, sort, sortKey, sortDir, onSort, emptyMessage }) {
+  const sorted = sort(rows)
+  if (sorted.length === 0) {
+    return <p className="text-muted text-sm font-body italic">{emptyMessage}</p>
+  }
+  return (
+    <div className="bg-surface border border-gold-dim/15 rounded-xl overflow-hidden overflow-x-auto">
+      <table className="w-full min-w-[640px]">
+        <thead>
+          <tr className="border-b border-gold-dim/20">
+            {columns.map(col => (
+              <th
+                key={col.key}
+                onClick={() => col.sortable !== false && onSort(col.key)}
+                className={`px-4 py-3.5 text-xs font-heading text-muted tracking-wider ${col.sortable === false ? '' : 'cursor-pointer group select-none hover:text-parchment/80'} transition-colors ${col.align === 'center' ? 'text-center' : 'text-left'}`}
+              >
+                {col.label}
+                {col.sortable !== false && <SortIcon active={sortKey === col.key} direction={sortDir} />}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row, idx) => (
+            <tr key={row.id ?? row.character ?? row.path ?? idx} className="border-b border-gold-dim/8 last:border-0 hover:bg-elevated/50 transition-colors">
+              {columns.map(col => (
+                <td
+                  key={col.key}
+                  className={`px-4 py-3 font-body text-sm ${col.align === 'center' ? 'text-center' : 'text-left'} ${col.accent ? 'text-gold/80' : 'text-parchment/70'}`}
+                >
+                  {col.format ? col.format(row[col.key], row) : (row[col.key] ?? 'NA')}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const pct = (v) => `${(v * 100).toFixed(1)}%`
+
+function CharactersTab({ games, allCharacters }) {
+  const [expansionFilter, setExpansionFilter] = useState('all')
+  const { sortKey, sortDir, toggle, sort } = useSort('games', 'desc')
+
+  const rows = useMemo(
+    () => computeCharacterStats(games, allCharacters),
+    [games, allCharacters],
+  )
+  const expansions = useMemo(() => {
+    const set = new Set(rows.map(r => r.expansion).filter(Boolean))
+    return Array.from(set).sort()
+  }, [rows])
+  const filtered = expansionFilter === 'all'
+    ? rows
+    : rows.filter(r => r.expansion === expansionFilter)
+
+  const columns = [
+    { key: 'character', label: 'Character', align: 'left' },
+    { key: 'expansion', label: 'Expansion', align: 'left' },
+    { key: 'games', label: 'Games', align: 'center' },
+    { key: 'wins', label: 'Wins', align: 'center' },
+    { key: 'winRate', label: 'Win %', align: 'center', format: pct, accent: true },
+    { key: 'deaths', label: 'Deaths', align: 'center' },
+    { key: 'deathRate', label: 'Death %', align: 'center', format: pct },
+  ]
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-body text-muted uppercase tracking-wider">Expansion</span>
+        <select
+          className="input-field text-sm py-1.5 w-auto"
+          value={expansionFilter}
+          onChange={e => setExpansionFilter(e.target.value)}
+        >
+          <option value="all">All</option>
+          {expansions.map(e => <option key={e} value={e}>{e}</option>)}
+        </select>
+      </div>
+      <StatsTable
+        columns={columns}
+        rows={filtered}
+        sort={sort}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSort={toggle}
+        emptyMessage="No character data yet."
+      />
+    </div>
+  )
+}
+
+function EndingsTab({ games }) {
+  const { sortKey, sortDir, toggle, sort } = useSort('times', 'desc')
+  const rows = useMemo(() => computeEndingStats(games), [games])
+
+  const columns = [
+    { key: 'name', label: 'Ending', align: 'left' },
+    { key: 'expansion', label: 'Expansion', align: 'left' },
+    { key: 'times', label: 'Times', align: 'center' },
+    { key: 'pctOfGames', label: '% Games', align: 'center', format: pct },
+    { key: 'playerWinRate', label: 'Player Win %', align: 'center', format: pct, accent: true },
+    { key: 'talismanWinRate', label: 'Talisman Win %', align: 'center', format: pct },
+    { key: 'topWinningCharacter', label: 'Top Winner', align: 'left', sortable: false },
+  ]
+
+  return (
+    <StatsTable
+      columns={columns}
+      rows={rows}
+      sort={sort}
+      sortKey={sortKey}
+      sortDir={sortDir}
+      onSort={toggle}
+      emptyMessage="No ending data yet."
+    />
+  )
+}
+
+function TotalCard({ label, value }) {
+  return (
+    <div className="bg-surface border border-gold-dim/15 rounded-xl px-5 py-4 flex-1 min-w-[180px]">
+      <p className="text-xs font-body text-muted uppercase tracking-wider">{label}</p>
+      <p className="font-display text-3xl text-gold mt-1 tracking-wider">{value}</p>
+    </div>
+  )
+}
+
+function ExpansionsTab({ games }) {
+  const dungeonSort = useSort('count', 'desc')
+  const pathTotalsSort = useSort('count', 'desc')
+  const pathByPathSort = useSort('count', 'desc')
+  const pathSort = useSort('count', 'desc')
+  const { dungeons, paths, pathsTotals, pathsByPath, totals } = useMemo(
+    () => computeExpansionEventStats(games),
+    [games],
+  )
+
+  const dungeonColumns = [
+    { key: 'character', label: 'Character', align: 'left' },
+    { key: 'count', label: 'Dungeons Beaten', align: 'center', accent: true },
+  ]
+  const pathTotalsColumns = [
+    { key: 'character', label: 'Character', align: 'left' },
+    { key: 'count', label: 'Paths Completed', align: 'center', accent: true },
+  ]
+  const pathByPathColumns = [
+    { key: 'path', label: 'Path', align: 'left' },
+    { key: 'count', label: 'Times Completed', align: 'center', accent: true },
+  ]
+  const pathColumns = [
+    { key: 'character', label: 'Character', align: 'left' },
+    { key: 'path', label: 'Path', align: 'left' },
+    { key: 'count', label: 'Completed', align: 'center', accent: true },
+  ]
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap gap-3">
+        <TotalCard label="Total Dungeons Beaten" value={totals.dungeons} />
+        <TotalCard label="Total Woodland Clears" value={totals.paths} />
+      </div>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Dungeons Beaten</h3>
+        <StatsTable
+          columns={dungeonColumns}
+          rows={dungeons}
+          sort={dungeonSort.sort}
+          sortKey={dungeonSort.sortKey}
+          sortDir={dungeonSort.sortDir}
+          onSort={dungeonSort.toggle}
+          emptyMessage="No dungeons beaten in this filter."
+        />
+      </section>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Total Paths by Path</h3>
+        <StatsTable
+          columns={pathByPathColumns}
+          rows={pathsByPath}
+          sort={pathByPathSort.sort}
+          sortKey={pathByPathSort.sortKey}
+          sortDir={pathByPathSort.sortDir}
+          onSort={pathByPathSort.toggle}
+          emptyMessage="No paths completed in this filter."
+        />
+      </section>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Total Paths per Character</h3>
+        <StatsTable
+          columns={pathTotalsColumns}
+          rows={pathsTotals}
+          sort={pathTotalsSort.sort}
+          sortKey={pathTotalsSort.sortKey}
+          sortDir={pathTotalsSort.sortDir}
+          onSort={pathTotalsSort.toggle}
+          emptyMessage="No paths completed in this filter."
+        />
+      </section>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Woodland Paths Breakdown</h3>
+        <StatsTable
+          columns={pathColumns}
+          rows={paths}
+          sort={pathSort.sort}
+          sortKey={pathSort.sortKey}
+          sortDir={pathSort.sortDir}
+          onSort={pathSort.toggle}
+          emptyMessage="No paths completed in this filter."
+        />
+      </section>
+    </div>
+  )
+}
+
+export default function Stats() {
+  const [tab, setTab] = useState('characters')
+  const [optionalFilter, setOptionalFilter] = useState('all')
+  const { data: rawGames = [], error, isLoading } = useStatsData()
+  const { data: allCharacters = [] } = useCharacters()
+
+  const games = useMemo(
+    () => filterGamesByOptionalExpansions(rawGames, optionalFilter),
+    [rawGames, optionalFilter],
+  )
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-6 animate-fade-up">
+        <h1 className="font-heading text-3xl text-parchment tracking-wide">Stats</h1>
+        <div className="ornament-divider mt-3">
+          <span className="text-gold-dim">&#9670;</span>
+        </div>
+        <p className="text-muted text-sm font-body mt-3">
+          Global breakdown of characters, endings, and expansion events.
+        </p>
+      </div>
+
+      {/* Optional-expansion filter */}
+      <div className="mb-6 flex flex-wrap items-center gap-2 animate-fade-up delay-1">
+        <span className="text-xs font-body text-muted uppercase tracking-wider mr-1">Filter</span>
+        {OPTIONAL_EXPANSION_FILTERS.map(f => {
+          const active = optionalFilter === f.key
+          return (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setOptionalFilter(f.key)}
+              className={`px-3 py-1.5 rounded-full text-xs font-body border transition-colors ${
+                active
+                  ? 'border-gold bg-gold/10 text-gold'
+                  : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
+              }`}
+            >
+              {f.label}
+            </button>
+          )
+        })}
+        <span className="ml-auto text-xs font-body text-muted">
+          {games.length} game{games.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Tab nav */}
+      <div className="mb-6 flex gap-1 border-b border-gold-dim/20 animate-fade-up delay-2">
+        {TABS.map(t => {
+          const active = tab === t.key
+          return (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setTab(t.key)}
+              className={`px-4 py-2.5 font-heading text-sm tracking-wide transition-colors border-b-2 -mb-px ${
+                active
+                  ? 'text-gold border-gold'
+                  : 'text-muted border-transparent hover:text-parchment/80'
+              }`}
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {error && (
+        <p className="text-danger text-sm font-body mb-4">{error.message}</p>
+      )}
+      {isLoading && (
+        <p className="text-muted text-sm font-body italic">Loading...</p>
+      )}
+
+      {!isLoading && (
+        <div className="animate-fade-up delay-3">
+          {tab === 'characters' && <CharactersTab games={games} allCharacters={allCharacters} />}
+          {tab === 'endings' && <EndingsTab games={games} />}
+          {tab === 'expansions' && <ExpansionsTab games={games} />}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/supabase/migrations/20260413000003_optional_expansions.sql
+++ b/supabase/migrations/20260413000003_optional_expansions.sql
@@ -1,0 +1,11 @@
+-- ============================================================
+-- Phase 6 — Optional expansions toggle on games
+-- ============================================================
+-- The Dragon and Harbinger expansions are played only sometimes
+-- (the rest are always on). Track which optional expansions were
+-- in play for each game so stats can split "normal" vs variants.
+--
+-- Expected values in the array: 'dragon', 'harbinger'.
+
+alter table games
+  add column optional_expansions text[] not null default '{}';

--- a/supabase/migrations/20260413000004_expansion_event_character.sql
+++ b/supabase/migrations/20260413000004_expansion_event_character.sql
@@ -1,0 +1,13 @@
+-- ============================================================
+-- Phase 6 — Attribute expansion events to a character
+-- ============================================================
+-- Dungeons beaten and woodland paths completed are now credited
+-- to the specific character that accomplished them, not just the
+-- player. Character is stored as plain text (no FK), matching
+-- characters_played on game_players.
+--
+-- Nullable so historical rows stay valid. New writes should
+-- always supply a character.
+
+alter table game_expansion_events
+  add column character text;


### PR DESCRIPTION
## Summary
Adds a new Stats screen at `/stats` with tabbed views for characters, endings, and expansion events. Introduces optional-expansion tracking (Dragon, Harbinger) on games and attributes dungeon/path events to specific characters so expansion stats can be grouped per character.

## Changes
- New `games.optional_expansions text[]` and `game_expansion_events.character text` columns (two migrations, applied)
- LogGame/EditGame: Dragon/Harbinger toggle pills, per-event character picker (auto-filled when only one character played), chars list moved below the add-character select
- Total deaths validated to equal characters played or one less
- New `/stats` route with filter (All / Normal / Dragon / Harbinger / Both, exclusive) and three tabs:
  - Characters: games, wins, win%, deaths, death%, filterable by expansion
  - Endings: times, % games, player win%, talisman win%, top winning character
  - Expansions: totals for dungeons and paths, dungeons per character, total paths per path, total paths per character, paths × character breakdown
- Highscores board: label now sits beside the icon
- Minor pre-existing bug fix: character dropdown optgroup referenced undefined `chars`