### PR TITLE
feat(games): add mandatory title field

### DIFF
--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -10,6 +10,7 @@ export function useGame(id) {
         .from('games')
         .select(`
           id,
+          title,
           date,
           notes,
           optional_expansions,
@@ -44,6 +45,7 @@ export function useGame(id) {
       if (error) throw error
       return {
         id: data.id,
+        title: data.title,
         date: data.date,
         notes: data.notes,
         optional_expansions: data.optional_expansions ?? [],

--- a/src/hooks/useGames.js
+++ b/src/hooks/useGames.js
@@ -9,6 +9,7 @@ export function useGames() {
         .from('games')
         .select(`
           id,
+          title,
           date,
           notes,
           created_at,
@@ -27,6 +28,7 @@ export function useGames() {
       if (error) throw error
       return data.map((g) => ({
         id: g.id,
+        title: g.title,
         date: g.date,
         notes: g.notes,
         createdAt: g.created_at,

--- a/src/hooks/useLogGame.js
+++ b/src/hooks/useLogGame.js
@@ -9,6 +9,7 @@ export function useLogGame() {
       const { data: game, error: gErr } = await supabase
         .from('games')
         .insert({
+          title: formState.title.trim(),
           date: formState.date,
           ending_id: formState.ending_id,
           notes: formState.notes || null,

--- a/src/hooks/useUpdateGame.js
+++ b/src/hooks/useUpdateGame.js
@@ -9,6 +9,7 @@ export function useUpdateGame() {
       const { error: gErr } = await supabase
         .from('games')
         .update({
+          title: formState.title.trim(),
           date: formState.date,
           ending_id: formState.ending_id,
           notes: formState.notes || null,

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -16,6 +16,7 @@ export default function EditGame() {
   if (isLoading || !game) return null
 
   const initialData = {
+    title: game.title ?? '',
     date: game.date,
     ending_id: game.ending?.id ?? '',
     notes: game.notes || '',

--- a/src/pages/GameDetail.jsx
+++ b/src/pages/GameDetail.jsx
@@ -76,7 +76,7 @@ export default function GameDetail() {
             <Link to="/history" className="text-muted text-sm font-body hover:text-gold/60 transition-colors mb-2 inline-block">
               &larr; Back to History
             </Link>
-            <h1 className="font-heading text-3xl text-parchment tracking-wide">Game Detail</h1>
+            <h1 className="font-heading text-3xl text-parchment tracking-wide">{game.title}</h1>
           </div>
           <div className="flex gap-2 mt-6">
             <Link to={`/games/${game.id}/edit`} className="btn-outline text-sm">

--- a/src/pages/GameHistory.jsx
+++ b/src/pages/GameHistory.jsx
@@ -44,13 +44,16 @@ export default function GameHistory() {
               to={`/games/${game.id}`}
               className={`card-ornate block bg-surface border border-gold-dim/15 rounded-xl p-5 hover:border-gold-dim/30 hover:bg-surface/90 transition-all duration-200 group animate-fade-up delay-${i + 1}`}
             >
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-3">
-                <div className="flex items-center gap-3">
-                  <time className="text-sm font-body text-muted">{formatDate(game.date)}</time>
-                  <span className="text-gold-dim/40">|</span>
-                  <span className="text-sm font-heading text-parchment/80 tracking-wide">{game.ending.name}</span>
+              <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 mb-3">
+                <div className="flex-1 min-w-0">
+                  <h2 className="font-heading text-lg text-parchment tracking-wide truncate">{game.title}</h2>
+                  <div className="flex items-center gap-3 mt-1">
+                    <time className="text-xs font-body text-muted">{formatDate(game.date)}</time>
+                    <span className="text-gold-dim/40">|</span>
+                    <span className="text-xs font-heading text-parchment/70 tracking-wide">{game.ending.name}</span>
+                  </div>
                 </div>
-                <span className="text-xs font-body text-muted group-hover:text-gold/60 transition-colors">
+                <span className="text-xs font-body text-muted group-hover:text-gold/60 transition-colors shrink-0">
                   View details &rarr;
                 </span>
               </div>

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -30,7 +30,10 @@ const WOODLAND_PATHS = [
   'Dark Path',
 ]
 
+const TITLE_MAX_LENGTH = 100
+
 const INITIAL_STATE = {
+  title: '',
   date: new Date().toISOString().split('T')[0],
   ending_id: '',
   notes: '',
@@ -314,6 +317,11 @@ export default function LogGame({ initialData, isEditing, gameId }) {
     return d !== n && d !== n - 1
   })
   const step1Errors = {
+    title: !form.title?.trim()
+      ? 'Title is required'
+      : form.title.trim().length > TITLE_MAX_LENGTH
+        ? `Title must be ${TITLE_MAX_LENGTH} characters or fewer`
+        : null,
     date: !form.date ? 'Date is required' : null,
     ending_id: !form.ending_id ? 'Ending is required' : null,
     players: form.players.length < 2 ? 'Select at least 2 players' : null,
@@ -411,6 +419,20 @@ export default function LogGame({ initialData, isEditing, gameId }) {
           <section className="animate-fade-up delay-1">
             <SectionHeader title="Game Setup" subtitle="When did the battle take place?" />
             <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-body text-parchment/80 mb-1.5">Title</label>
+                <input
+                  type="text"
+                  className="input-field"
+                  maxLength={TITLE_MAX_LENGTH}
+                  placeholder="e.g. The Night the Toad Rose"
+                  value={form.title}
+                  onChange={e => updateForm('title', e.target.value)}
+                />
+                {step1Attempted && step1Errors.title && (
+                  <p className="text-danger text-xs mt-1 font-body">{step1Errors.title}</p>
+                )}
+              </div>
               <div>
                 <label className="block text-sm font-body text-parchment/80 mb-1.5">Date</label>
                 <input
@@ -882,6 +904,8 @@ export default function LogGame({ initialData, isEditing, gameId }) {
           <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 mb-6">
             <h3 className="font-heading text-base text-parchment tracking-wide mb-4">Summary</h3>
             <div className="grid grid-cols-2 gap-y-3 gap-x-6 text-sm font-body">
+              <span className="text-muted">Title</span>
+              <span className="text-parchment">{form.title?.trim() || 'NA'}</span>
               <span className="text-muted">Date</span>
               <span className="text-parchment">{form.date || 'NA'}</span>
               <span className="text-muted">Ending</span>

--- a/supabase/migrations/20260414000000_add_game_title.sql
+++ b/supabase/migrations/20260414000000_add_game_title.sql
@@ -1,0 +1,9 @@
+-- Add mandatory title column to games
+alter table games add column title text;
+
+update games
+set title = 'Game on ' || to_char(date, 'YYYY-MM-DD')
+where title is null;
+
+alter table games alter column title set not null;
+alter table games add constraint games_title_length check (char_length(title) between 1 and 100);


### PR DESCRIPTION
## Summary
- Adds a required `title` column to `games` (1–100 chars), backfilling existing rows as "Game on YYYY-MM-DD"
- Exposes the title in Log/Edit Game (above Date) with required validation, and in the review summary
- Shows title as the card heading in Game History and as the page h1 on Game Detail

Closes #25

## Test plan
- [ ] Log a new game — title required, cannot be empty, blocked past 100 chars
- [ ] Edit an existing game — title pre-fills and saves
- [ ] Game History list shows the title as the card heading
- [ ] Game Detail page shows title in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)