### PR TITLE
feat(games): track toad times per player, derive winning character

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -40,7 +40,11 @@
       "Bash(git push:*)",
       "Skill(pr)",
       "Bash(git fetch:*)",
-      "Bash(git rm:*)"
+      "Bash(git rm:*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "WebFetch(domain:talismantracker.netlify.app)",
+      "Bash(grep -rn \"Stats\\\\|Characters\" src/pages/Stats*.jsx)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -21,6 +21,7 @@ export function useGame(id) {
             id,
             characters_played,
             total_deaths,
+            total_toad_times,
             is_winner,
             winning_character,
             player:players ( id, name )
@@ -57,6 +58,7 @@ export function useGame(id) {
           player: gp.player,
           characters_played: gp.characters_played ?? [],
           total_deaths: gp.total_deaths,
+          total_toad_times: gp.total_toad_times ?? 0,
           is_winner: gp.is_winner,
           winning_character: gp.winning_character,
         })),

--- a/src/hooks/useGames.js
+++ b/src/hooks/useGames.js
@@ -18,6 +18,7 @@ export function useGames() {
             id,
             characters_played,
             total_deaths,
+            total_toad_times,
             is_winner,
             winning_character,
             player:players ( id, name )
@@ -38,6 +39,7 @@ export function useGames() {
           player: gp.player,
           characters_played: gp.characters_played ?? [],
           total_deaths: gp.total_deaths,
+          total_toad_times: gp.total_toad_times ?? 0,
           is_winner: gp.is_winner,
           winning_character: gp.winning_character,
         })),

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -15,26 +15,53 @@ const CATEGORY_LABELS = {
   most_denizens_on_spot: 'Most Denizens on Spot',
 }
 
+const DERIVED_CATEGORIES = {
+  most_deaths: 'total_deaths',
+  most_toad_times: 'total_toad_times',
+}
+
 export function useHighscoreRecords() {
   return useQuery({
     queryKey: ['highscoreRecords'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('game_highscores')
-        .select(`
-          category,
-          value,
-          player:players ( id, name ),
-          game:games ( id, date )
-        `)
+      const [hsResult, gpResult] = await Promise.all([
+        supabase
+          .from('game_highscores')
+          .select(`
+            category,
+            value,
+            player:players ( id, name ),
+            game:games ( id, date )
+          `),
+        supabase
+          .from('game_players')
+          .select(`
+            total_deaths,
+            total_toad_times,
+            player:players ( id, name ),
+            game:games ( id, date )
+          `),
+      ])
 
-      if (error) throw error
+      if (hsResult.error) throw hsResult.error
+      if (gpResult.error) throw gpResult.error
 
       const topByCategory = new Map()
-      for (const row of data) {
+      for (const row of hsResult.data) {
         if (!topByCategory.has(row.category)) topByCategory.set(row.category, [])
         topByCategory.get(row.category).push(row)
       }
+
+      for (const [category, column] of Object.entries(DERIVED_CATEGORIES)) {
+        const rows = []
+        for (const gp of gpResult.data) {
+          const value = Number(gp[column] ?? 0)
+          if (value <= 0) continue
+          rows.push({ category, value, player: gp.player, game: gp.game })
+        }
+        topByCategory.set(category, rows)
+      }
+
       for (const [category, rows] of topByCategory) {
         rows.sort((a, b) => Number(b.value) - Number(a.value))
         topByCategory.set(category, rows.slice(0, 5))

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -12,6 +12,7 @@ export function useLeaderboardStats() {
           game_id,
           characters_played,
           total_deaths,
+          total_toad_times,
           is_winner,
           player:players ( id, name )
         `)

--- a/src/lib/gameWrites.js
+++ b/src/lib/gameWrites.js
@@ -3,13 +3,15 @@ import { supabase } from '../supabaseClient'
 export function buildGamePlayerRows(gameId, formState) {
   return formState.players.map((playerId) => {
     const pd = formState.playerData?.[playerId] ?? {}
+    const chars = pd.characters_played ?? []
     return {
       game_id: gameId,
       player_id: playerId,
-      characters_played: pd.characters_played ?? [],
+      characters_played: chars,
       total_deaths: Number(pd.total_deaths ?? 0),
+      total_toad_times: Number(pd.total_toad_times ?? 0),
       is_winner: !!pd.is_winner,
-      winning_character: pd.is_winner ? pd.winning_character ?? null : null,
+      winning_character: pd.is_winner && chars.length > 0 ? chars[chars.length - 1] : null,
     }
   })
 }

--- a/src/lib/statsHelpers.js
+++ b/src/lib/statsHelpers.js
@@ -15,6 +15,7 @@ export function computeLeaderboard(gamePlayers) {
         games_played: 0,
         wins: 0,
         total_deaths: 0,
+        total_toad_times: 0,
         character_counts: new Map(),
       })
     }
@@ -22,6 +23,7 @@ export function computeLeaderboard(gamePlayers) {
     row.games_played += 1
     if (gp.is_winner) row.wins += 1
     row.total_deaths += gp.total_deaths ?? 0
+    row.total_toad_times += gp.total_toad_times ?? 0
     for (const c of gp.characters_played ?? []) {
       row.character_counts.set(c, (row.character_counts.get(c) ?? 0) + 1)
     }
@@ -48,6 +50,8 @@ export function computeLeaderboard(gamePlayers) {
         win_rate: row.games_played > 0 ? (row.wins / row.games_played) * 100 : 0,
         total_deaths: row.total_deaths,
         avg_deaths: row.games_played > 0 ? row.total_deaths / row.games_played : 0,
+        total_toad_times: row.total_toad_times,
+        avg_toad_times: row.games_played > 0 ? row.total_toad_times / row.games_played : 0,
         most_played: mostPlayed,
       }
     })
@@ -61,6 +65,8 @@ export function computeLeaderboard(gamePlayers) {
       win_rate: (talismanWins / totalGames) * 100,
       total_deaths: 0,
       avg_deaths: 0,
+      total_toad_times: 0,
+      avg_toad_times: 0,
       most_played: '—',
     })
   }

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -26,8 +26,8 @@ export default function EditGame() {
       acc[p.player.id] = {
         characters_played: p.characters_played,
         total_deaths: p.total_deaths,
+        total_toad_times: p.total_toad_times ?? 0,
         is_winner: p.is_winner,
-        winning_character: p.winning_character,
       }
       return acc
     }, {}),

--- a/src/pages/GameDetail.jsx
+++ b/src/pages/GameDetail.jsx
@@ -19,8 +19,6 @@ const CATEGORY_LABELS = {
   most_strength: 'Most Strength (without bonus)',
   most_craft: 'Most Craft (without bonus)',
   most_life: 'Most Life',
-  most_deaths: 'Most Deaths',
-  most_toad_times: 'Most Times Turned Into Toad',
   longest_toad_streak: 'Longest Toad Streak (consecutive turns)',
   most_denizens_on_spot: 'Most Denizens on Spot',
 }
@@ -158,6 +156,9 @@ export default function GameDetail() {
                 </div>
                 <span className="text-muted text-sm font-body">
                   {gp.total_deaths} death{gp.total_deaths !== 1 ? 's' : ''}
+                  {(gp.total_toad_times ?? 0) > 0 && (
+                    <> &middot; {gp.total_toad_times} toad time{gp.total_toad_times !== 1 ? 's' : ''}</>
+                  )}
                 </span>
               </div>
               <div className="flex flex-wrap gap-2">

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -8,6 +8,8 @@ const COLUMNS = [
   { key: 'win_rate', label: 'Win %', align: 'center', format: v => `${v.toFixed(1)}%` },
   { key: 'total_deaths', label: 'Deaths', align: 'center' },
   { key: 'avg_deaths', label: 'Avg Deaths', align: 'center', format: v => v.toFixed(2) },
+  { key: 'total_toad_times', label: 'Toads', align: 'center' },
+  { key: 'avg_toad_times', label: 'Avg Toads', align: 'center', format: v => v.toFixed(2) },
   { key: 'most_played', label: 'Most Played', align: 'left' },
 ]
 
@@ -135,13 +137,21 @@ export default function Leaderboard() {
                 <span className="text-muted block text-xs">Deaths</span>
                 <span className="text-parchment/80">{player.total_deaths}</span>
               </div>
-              <div className="col-span-2">
-                <span className="text-muted block text-xs">Most Played</span>
-                <span className="text-parchment/80">{player.most_played}</span>
-              </div>
               <div>
                 <span className="text-muted block text-xs">Avg Deaths</span>
                 <span className="text-parchment/80">{player.avg_deaths.toFixed(2)}</span>
+              </div>
+              <div>
+                <span className="text-muted block text-xs">Toads</span>
+                <span className="text-parchment/80">{player.total_toad_times}</span>
+              </div>
+              <div>
+                <span className="text-muted block text-xs">Avg Toads</span>
+                <span className="text-parchment/80">{player.avg_toad_times.toFixed(2)}</span>
+              </div>
+              <div className="col-span-3">
+                <span className="text-muted block text-xs">Most Played</span>
+                <span className="text-parchment/80">{player.most_played}</span>
               </div>
             </div>
           </div>

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -16,8 +16,6 @@ const HIGHSCORE_CATEGORIES = [
   { key: 'most_strength', label: 'Most Strength' },
   { key: 'most_craft', label: 'Most Craft' },
   { key: 'most_life', label: 'Most Life' },
-  { key: 'most_deaths', label: 'Most Deaths' },
-  { key: 'most_toad_times', label: 'Most Times Turned Into Toad' },
   { key: 'longest_toad_streak', label: 'Longest Toad Streak' },
   { key: 'most_denizens_on_spot', label: 'Most Denizens on Spot', gameLevel: true },
 ]
@@ -120,7 +118,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
       const playerData = { ...prev.playerData }
       const expansionEvents = { ...prev.expansionEvents }
       if (!exists) {
-        playerData[playerId] = { characters_played: [], total_deaths: 0, is_winner: false, winning_character: null }
+        playerData[playerId] = { characters_played: [], total_deaths: 0, total_toad_times: 0, is_winner: false }
         expansionEvents[playerId] = emptyPlayerEvents()
       } else {
         delete playerData[playerId]
@@ -144,19 +142,11 @@ export default function LogGame({ initialData, isEditing, gameId }) {
     setForm(prev => {
       const current = prev.playerData[playerId]
       if (!current) return prev
-      const nextIsWinner = !current.is_winner
-      const chars = current.characters_played
       return {
         ...prev,
         playerData: {
           ...prev.playerData,
-          [playerId]: {
-            ...current,
-            is_winner: nextIsWinner,
-            winning_character: nextIsWinner
-              ? (current.winning_character || (chars.length > 0 ? chars[chars.length - 1] : null))
-              : null,
-          },
+          [playerId]: { ...current, is_winner: !current.is_winner },
         },
       }
     })
@@ -635,39 +625,34 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                         )}
                       </div>
 
-                      {/* Deaths */}
-                      <div className="mb-4">
-                        <label className="block text-sm font-body text-parchment/70 mb-1.5">Total Deaths</label>
-                        <input
-                          type="number"
-                          min="0"
-                          className="input-field w-24"
-                          value={data.total_deaths}
-                          onChange={e => updatePlayerData(player.id, 'total_deaths', parseInt(e.target.value) || 0)}
-                        />
-                        {step1Attempted && playersWithInvalidDeaths.includes(player.id) && (
-                          <p className="text-danger text-xs mt-1.5 font-body">
-                            Must be {Math.max(0, data.characters_played.length - 1)} or {data.characters_played.length}
-                          </p>
-                        )}
-                      </div>
-
-                      {/* Winning character override */}
-                      {data.is_winner && (
-                        <div className="mb-4 p-3 bg-gold/5 border border-gold/20 rounded-lg">
-                          <label className="block text-sm font-body text-gold/80 mb-1.5">Winning Character</label>
-                          <select
-                            className="input-field text-sm"
-                            value={data.winning_character || ''}
-                            onChange={e => updatePlayerData(player.id, 'winning_character', e.target.value)}
-                          >
-                            <option value="">Select...</option>
-                            {data.characters_played.map((char, idx) => (
-                              <option key={idx} value={char}>{char}</option>
-                            ))}
-                          </select>
+                      {/* Deaths & Toad times */}
+                      <div className="mb-4 flex gap-4">
+                        <div>
+                          <label className="block text-sm font-body text-parchment/70 mb-1.5">Total Deaths</label>
+                          <input
+                            type="number"
+                            min="0"
+                            className="input-field w-24"
+                            value={data.total_deaths}
+                            onChange={e => updatePlayerData(player.id, 'total_deaths', parseInt(e.target.value) || 0)}
+                          />
+                          {step1Attempted && playersWithInvalidDeaths.includes(player.id) && (
+                            <p className="text-danger text-xs mt-1.5 font-body">
+                              Must be {Math.max(0, data.characters_played.length - 1)} or {data.characters_played.length}
+                            </p>
+                          )}
                         </div>
-                      )}
+                        <div>
+                          <label className="block text-sm font-body text-parchment/70 mb-1.5">Times Toadified</label>
+                          <input
+                            type="number"
+                            min="0"
+                            className="input-field w-24"
+                            value={data.total_toad_times ?? 0}
+                            onChange={e => updatePlayerData(player.id, 'total_toad_times', Math.max(0, parseInt(e.target.value) || 0))}
+                          />
+                        </div>
+                      </div>
 
                       {/* Expansion Events */}
                       <div className="border-t border-gold-dim/15 pt-4 mt-2">
@@ -943,6 +928,9 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                         <span className="text-parchment/60">
                           {data.characters_played.length > 0 ? data.characters_played.join(' \u2192 ') : 'No characters'}
                           {' \u00b7 '}{data.total_deaths} death{data.total_deaths !== 1 ? 's' : ''}
+                          {(data.total_toad_times ?? 0) > 0 && (
+                            <>{' \u00b7 '}{data.total_toad_times} toad{data.total_toad_times !== 1 ? 's' : ''}</>
+                          )}
                         </span>
                       </div>
                     )

--- a/supabase/migrations/20260415000000_toad_times_and_derive_deaths.sql
+++ b/supabase/migrations/20260415000000_toad_times_and_derive_deaths.sql
@@ -1,0 +1,27 @@
+-- Add total_toad_times to game_players and stop storing most_deaths /
+-- most_toad_times in game_highscores. Both are now derived from
+-- game_players on the client (see useHighscoreRecords).
+
+alter table game_players
+  add column total_toad_times int not null default 0
+    check (total_toad_times >= 0);
+
+delete from game_highscores
+  where category in ('most_deaths', 'most_toad_times');
+
+alter table game_highscores
+  drop constraint game_highscores_category_check;
+
+alter table game_highscores
+  add constraint game_highscores_category_check
+    check (category in (
+      'most_followers',
+      'most_objects',
+      'most_denizens_on_spot',
+      'most_gold',
+      'most_fate',
+      'most_strength',
+      'most_craft',
+      'most_life',
+      'longest_toad_streak'
+    ));


### PR DESCRIPTION
## Summary
Resolves #27. Toad times and deaths are now first-class per-player fields on `game_players` rather than user-entered highscore rows, and the "Most Times Turned Into Toad" / "Most Deaths" board records are derived from that column. Also drops the manual Winning Character selector — it's auto-set to the last character played.

## Changes
- Migration adds `game_players.total_toad_times` and removes `most_deaths` / `most_toad_times` from the `game_highscores` category enum.
- Log Game wizard: new "Times Toadified" input next to Total Deaths; removed the Winning Character override; removed the two redundant highscore categories.
- `winning_character` is derived at write time in `gameWrites.js` as the last entry in `characters_played` when `is_winner`.
- `useHighscoreRecords` fetches `game_players` in parallel and synthesizes `most_deaths` / `most_toad_times` client-side (top 5 per category).
- Leaderboard gains `Toads` and `Avg Toads` columns (desktop + mobile).
- GameDetail shows toad times inline on each player row when > 0; drops derived categories from its highscore label map.
- Stats → Characters intentionally untouched — toad events can't be reliably attributed to a specific character.