### PR TITLE
fix(log-game): scroll to top on step transitions

### DIFF
--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -742,7 +742,10 @@ export default function LogGame({ initialData, isEditing, gameId }) {
               className="btn-gold w-full"
               onClick={() => {
                 setStep1Attempted(true)
-                if (!step1HasErrors) setStep(2)
+                if (!step1HasErrors) {
+                  setStep(2)
+                  window.scrollTo({ top: 0, behavior: 'instant' })
+                }
               }}
             >
               Continue to Highscores &#8594;
@@ -981,7 +984,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
             <button
               type="button"
               className="btn-outline"
-              onClick={() => setStep(1)}
+              onClick={() => { setStep(1); window.scrollTo({ top: 0, behavior: 'instant' }) }}
             >
               &#8592; Back
             </button>


### PR DESCRIPTION
## Summary
On mobile, navigating between steps in the log game form left the viewport at the user's current scroll position, requiring manual scroll-up. Both step transitions now reset scroll to the top.

## Changes
- Scroll to top when advancing from step 1 to step 2 (Continue to Highscores)
- Scroll to top when going back from step 2 to step 1 (Back)