### PR TITLE
feat: death tracking, leaderboard stats, and UI polish

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -44,7 +44,8 @@
       "Bash(git add *)",
       "Bash(git commit *)",
       "WebFetch(domain:talismantracker.netlify.app)",
-      "Bash(grep -rn \"Stats\\\\|Characters\" src/pages/Stats*.jsx)"
+      "Bash(grep -rn \"Stats\\\\|Characters\" src/pages/Stats*.jsx)",
+      "WebFetch(domain:cdn.1j1ju.com)"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/src/hooks/useDeathTypes.js
+++ b/src/hooks/useDeathTypes.js
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+
+export function useDeathTypes() {
+  return useQuery({
+    queryKey: ['deathTypes'],
+    staleTime: Infinity,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('death_types')
+        .select('id, name, description')
+        .order('name', { ascending: true })
+      if (error) throw error
+      return data
+    },
+  })
+}

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -20,7 +20,6 @@ export function useGame(id) {
           players:game_players (
             id,
             characters_played,
-            total_deaths,
             total_toad_times,
             is_winner,
             winning_character,
@@ -39,11 +38,20 @@ export function useGame(id) {
             detail,
             character,
             player:players ( id, name )
+          ),
+          deaths:game_player_deaths (
+            id,
+            player_id,
+            killed_by_player_id,
+            death_type:death_types ( id, name ),
+            character:characters ( id, name ),
+            killed_by:players!game_player_deaths_killed_by_fkey ( id, name )
           )
         `)
         .eq('id', id)
         .single()
       if (error) throw error
+      const allDeaths = data.deaths ?? []
       return {
         id: data.id,
         title: data.title,
@@ -53,15 +61,19 @@ export function useGame(id) {
         createdAt: data.created_at,
         updatedAt: data.updated_at,
         ending: data.ending,
-        players: (data.players ?? []).map((gp) => ({
-          id: gp.id,
-          player: gp.player,
-          characters_played: gp.characters_played ?? [],
-          total_deaths: gp.total_deaths,
-          total_toad_times: gp.total_toad_times ?? 0,
-          is_winner: gp.is_winner,
-          winning_character: gp.winning_character,
-        })),
+        players: (data.players ?? []).map((gp) => {
+          const playerDeaths = allDeaths.filter(d => d.player_id === gp.player.id)
+          return {
+            id: gp.id,
+            player: gp.player,
+            characters_played: gp.characters_played ?? [],
+            total_deaths: playerDeaths.length,
+            deaths: playerDeaths,
+            total_toad_times: gp.total_toad_times ?? 0,
+            is_winner: gp.is_winner,
+            winning_character: gp.winning_character,
+          }
+        }),
         highscores: data.highscores ?? [],
         expansion_events: data.expansion_events ?? [],
       }

--- a/src/hooks/useGames.js
+++ b/src/hooks/useGames.js
@@ -17,7 +17,6 @@ export function useGames() {
           players:game_players (
             id,
             characters_played,
-            total_deaths,
             total_toad_times,
             is_winner,
             winning_character,
@@ -38,7 +37,6 @@ export function useGames() {
           id: gp.id,
           player: gp.player,
           characters_played: gp.characters_played ?? [],
-          total_deaths: gp.total_deaths,
           total_toad_times: gp.total_toad_times ?? 0,
           is_winner: gp.is_winner,
           winning_character: gp.winning_character,

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -24,7 +24,7 @@ export function useHighscoreRecords() {
   return useQuery({
     queryKey: ['highscoreRecords'],
     queryFn: async () => {
-      const [hsResult, gpResult] = await Promise.all([
+      const [hsResult, gpResult, deathResult] = await Promise.all([
         supabase
           .from('game_highscores')
           .select(`
@@ -36,15 +36,30 @@ export function useHighscoreRecords() {
         supabase
           .from('game_players')
           .select(`
-            total_deaths,
+            game_id,
             total_toad_times,
             player:players ( id, name ),
             game:games ( id, date )
           `),
+        supabase
+          .from('game_player_deaths')
+          .select('game_id, player_id'),
       ])
 
       if (hsResult.error) throw hsResult.error
       if (gpResult.error) throw gpResult.error
+      if (deathResult.error) throw deathResult.error
+
+      const deathCounts = new Map()
+      for (const d of deathResult.data) {
+        const key = `${d.game_id}::${d.player_id}`
+        deathCounts.set(key, (deathCounts.get(key) ?? 0) + 1)
+      }
+
+      gpResult.data = gpResult.data.map(gp => ({
+        ...gp,
+        total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
+      }))
 
       const topByCategory = new Map()
       for (const row of hsResult.data) {

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -6,17 +6,33 @@ export function useLeaderboardStats() {
   return useQuery({
     queryKey: ['leaderboardStats'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('game_players')
-        .select(`
-          game_id,
-          characters_played,
-          total_deaths,
-          total_toad_times,
-          is_winner,
-          player:players ( id, name )
-        `)
-      if (error) throw error
+      const [gpResult, deathResult] = await Promise.all([
+        supabase
+          .from('game_players')
+          .select(`
+            game_id,
+            characters_played,
+            total_toad_times,
+            is_winner,
+            player:players ( id, name )
+          `),
+        supabase
+          .from('game_player_deaths')
+          .select('game_id, player_id'),
+      ])
+      if (gpResult.error) throw gpResult.error
+      if (deathResult.error) throw deathResult.error
+
+      const deathCounts = new Map()
+      for (const d of deathResult.data) {
+        const key = `${d.game_id}::${d.player_id}`
+        deathCounts.set(key, (deathCounts.get(key) ?? 0) + 1)
+      }
+
+      const data = gpResult.data.map(gp => ({
+        ...gp,
+        total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
+      }))
       return computeLeaderboard(data)
     },
   })

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -18,22 +18,30 @@ export function useLeaderboardStats() {
           `),
         supabase
           .from('game_player_deaths')
-          .select('game_id, player_id'),
+          .select('game_id, player_id, death_type:death_types(name)'),
       ])
       if (gpResult.error) throw gpResult.error
       if (deathResult.error) throw deathResult.error
 
       const deathCounts = new Map()
+      const deathTypesByPlayer = new Map()
       for (const d of deathResult.data) {
         const key = `${d.game_id}::${d.player_id}`
         deathCounts.set(key, (deathCounts.get(key) ?? 0) + 1)
+
+        const typeName = d.death_type?.name
+        if (typeName) {
+          const counts = deathTypesByPlayer.get(d.player_id) ?? new Map()
+          counts.set(typeName, (counts.get(typeName) ?? 0) + 1)
+          deathTypesByPlayer.set(d.player_id, counts)
+        }
       }
 
       const data = gpResult.data.map(gp => ({
         ...gp,
         total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
       }))
-      return computeLeaderboard(data)
+      return computeLeaderboard(data, deathTypesByPlayer)
     },
   })
 }

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -14,11 +14,13 @@ export function useLeaderboardStats() {
             characters_played,
             total_toad_times,
             is_winner,
-            player:players ( id, name )
+            winning_character,
+            player:players ( id, name ),
+            game:games ( id, created_at )
           `),
         supabase
           .from('game_player_deaths')
-          .select('game_id, player_id, death_type:death_types(name)'),
+          .select('game_id, player_id, killed_by_player_id, death_type:death_types(name)'),
       ])
       if (gpResult.error) throw gpResult.error
       if (deathResult.error) throw deathResult.error
@@ -41,7 +43,7 @@ export function useLeaderboardStats() {
         ...gp,
         total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
       }))
-      return computeLeaderboard(data, deathTypesByPlayer)
+      return computeLeaderboard(data, deathTypesByPlayer, deathResult.data)
     },
   })
 }

--- a/src/hooks/useStatsData.js
+++ b/src/hooks/useStatsData.js
@@ -14,7 +14,6 @@ export function useStatsData() {
           players:game_players (
             id,
             characters_played,
-            total_deaths,
             is_winner,
             winning_character,
             player:players ( id, name )
@@ -26,10 +25,28 @@ export function useStatsData() {
             detail,
             character,
             player:players ( id, name )
+          ),
+          deaths:game_player_deaths (
+            id,
+            player_id,
+            killed_by_player_id,
+            death_type:death_types ( id, name ),
+            character:characters ( id, name ),
+            killed_by:players!game_player_deaths_killed_by_fkey ( id, name )
           )
         `)
       if (error) throw error
-      return data ?? []
+      return (data ?? []).map(game => {
+        const allDeaths = game.deaths ?? []
+        return {
+          ...game,
+          players: (game.players ?? []).map(gp => ({
+            ...gp,
+            total_deaths: allDeaths.filter(d => d.player_id === gp.player.id).length,
+            deaths: allDeaths.filter(d => d.player_id === gp.player.id),
+          })),
+        }
+      })
     },
   })
 }

--- a/src/lib/gameWrites.js
+++ b/src/lib/gameWrites.js
@@ -8,7 +8,6 @@ export function buildGamePlayerRows(gameId, formState) {
       game_id: gameId,
       player_id: playerId,
       characters_played: chars,
-      total_deaths: Number(pd.total_deaths ?? 0),
       total_toad_times: Number(pd.total_toad_times ?? 0),
       is_winner: !!pd.is_winner,
       winning_character: pd.is_winner && chars.length > 0 ? chars[chars.length - 1] : null,
@@ -32,6 +31,24 @@ export function buildHighscoreRows(gameId, formState) {
         player_id: isGameLevel ? null : entry.player_id,
         category,
         value: Number(entry.value),
+      })
+    }
+  }
+  return rows
+}
+
+export function buildDeathRows(gameId, formState) {
+  const rows = []
+  for (const playerId of formState.players ?? []) {
+    const deaths = formState.playerData?.[playerId]?.deaths ?? []
+    for (const death of deaths) {
+      if (!death.death_type_id) continue
+      rows.push({
+        game_id: gameId,
+        player_id: playerId,
+        death_type_id: death.death_type_id,
+        character_id: death.character_id,
+        killed_by_player_id: death.killed_by_player_id || null,
       })
     }
   }
@@ -91,6 +108,12 @@ export async function insertChildRows(gameId, formState) {
     if (hErr) throw hErr
   }
 
+  const deathRows = buildDeathRows(gameId, formState)
+  if (deathRows.length > 0) {
+    const { error: dErr } = await supabase.from('game_player_deaths').insert(deathRows)
+    if (dErr) throw dErr
+  }
+
   const eventRows = buildExpansionEventRows(gameId, formState)
   if (eventRows.length > 0) {
     const { error: eErr } = await supabase.from('game_expansion_events').insert(eventRows)
@@ -99,7 +122,7 @@ export async function insertChildRows(gameId, formState) {
 }
 
 export async function deleteChildRows(gameId) {
-  const tables = ['game_players', 'game_highscores', 'game_expansion_events']
+  const tables = ['game_player_deaths', 'game_players', 'game_highscores', 'game_expansion_events']
   for (const table of tables) {
     const { error } = await supabase.from(table).delete().eq('game_id', gameId)
     if (error) throw error

--- a/src/lib/statsAggregations.js
+++ b/src/lib/statsAggregations.js
@@ -143,6 +143,7 @@ export function computeEndingStats(games) {
         times: 0,
         playerWins: 0,
         talismanWins: 0,
+        totalDeaths: 0,
         winningCharCounts: new Map(),
         deathTypeCounts: new Map(),
       })
@@ -165,6 +166,7 @@ export function computeEndingStats(games) {
     }
     for (const gp of game.players ?? []) {
       for (const d of gp.deaths ?? []) {
+        row.totalDeaths += 1
         const typeName = d.death_type?.name
         if (typeName) {
           row.deathTypeCounts.set(typeName, (row.deathTypeCounts.get(typeName) ?? 0) + 1)
@@ -199,6 +201,7 @@ export function computeEndingStats(games) {
       pctOfGames: totalGames > 0 ? row.times / totalGames : 0,
       playerWinRate: row.times > 0 ? row.playerWins / row.times : 0,
       talismanWinRate: row.times > 0 ? row.talismanWins / row.times : 0,
+      avgDeathsPerGame: row.times > 0 ? row.totalDeaths / row.times : 0,
       topWinningCharacter: topChar ? `${topChar} (${topCount})` : 'NA',
       topDeath: topDeathType ? `${topDeathType} (${topDeathCount})` : 'NA',
     }
@@ -249,6 +252,26 @@ export function computePlayerDeathBreakdown(games) {
   return Array.from(stats.values())
 }
 
+// Per-character death breakdown by type.
+export function computeCharacterDeathBreakdown(games) {
+  const stats = new Map()
+
+  for (const game of games) {
+    for (const gp of game.players ?? []) {
+      for (const d of gp.deaths ?? []) {
+        const character = d.character?.name ?? 'Unknown'
+        const deathType = d.death_type?.name ?? 'Unknown'
+        const key = `${character}::${deathType}`
+        const row = stats.get(key) ?? { character, deathType, count: 0 }
+        row.count += 1
+        stats.set(key, row)
+      }
+    }
+  }
+
+  return Array.from(stats.values())
+}
+
 // PVP kill leaderboard: who kills who.
 export function computePvpKillLeaderboard(games) {
   const stats = new Map()
@@ -277,9 +300,12 @@ export function computePvpKillLeaderboard(games) {
 // Events with no character attribution are grouped as "Unknown".
 export function computeExpansionEventStats(games) {
   const dungeons = new Map()     // character -> { character, count }
+  const dungeonsByPlayer = new Map() // playerName -> { playerName, count }
   const paths = new Map()        // `${character}::${path}` -> { character, path, count }
   const pathsTotals = new Map()  // character -> { character, count }
+  const pathsTotalsByPlayer = new Map() // playerName -> { playerName, count }
   const pathsByPath = new Map()  // path -> { path, count }
+  const pathsByPlayer = new Map() // `${playerName}::${path}` -> { playerName, path, count }
   let totalDungeons = 0
   let totalPaths = 0
 
@@ -290,6 +316,10 @@ export function computeExpansionEventStats(games) {
         const row = dungeons.get(character) ?? { character, count: 0 }
         row.count += 1
         dungeons.set(character, row)
+        const playerName = ev.player?.name ?? 'Unknown'
+        const playerRow = dungeonsByPlayer.get(playerName) ?? { playerName, count: 0 }
+        playerRow.count += 1
+        dungeonsByPlayer.set(playerName, playerRow)
         totalDungeons += 1
       } else if (ev.event_type === 'path_completed') {
         const path = ev.detail || 'NA'
@@ -300,9 +330,17 @@ export function computeExpansionEventStats(games) {
         const totalRow = pathsTotals.get(character) ?? { character, count: 0 }
         totalRow.count += 1
         pathsTotals.set(character, totalRow)
+        const playerName = ev.player?.name ?? 'Unknown'
+        const playerTotalRow = pathsTotalsByPlayer.get(playerName) ?? { playerName, count: 0 }
+        playerTotalRow.count += 1
+        pathsTotalsByPlayer.set(playerName, playerTotalRow)
         const pathRow = pathsByPath.get(path) ?? { path, count: 0 }
         pathRow.count += 1
         pathsByPath.set(path, pathRow)
+        const playerPathKey = `${playerName}::${path}`
+        const playerPathRow = pathsByPlayer.get(playerPathKey) ?? { playerName, path, count: 0 }
+        playerPathRow.count += 1
+        pathsByPlayer.set(playerPathKey, playerPathRow)
         totalPaths += 1
       }
     }
@@ -310,9 +348,12 @@ export function computeExpansionEventStats(games) {
 
   return {
     dungeons: Array.from(dungeons.values()),
+    dungeonsByPlayer: Array.from(dungeonsByPlayer.values()),
     paths: Array.from(paths.values()),
     pathsTotals: Array.from(pathsTotals.values()),
+    pathsTotalsByPlayer: Array.from(pathsTotalsByPlayer.values()),
     pathsByPath: Array.from(pathsByPath.values()),
+    pathsByPlayer: Array.from(pathsByPlayer.values()),
     totals: { dungeons: totalDungeons, paths: totalPaths },
   }
 }

--- a/src/lib/statsAggregations.js
+++ b/src/lib/statsAggregations.js
@@ -49,6 +49,7 @@ export function computeCharacterStats(games, allCharacters) {
         games: 0,
         wins: 0,
         deaths: 0,
+        deathTypeCounts: new Map(),
       })
     }
     return stats.get(name)
@@ -57,13 +58,25 @@ export function computeCharacterStats(games, allCharacters) {
   for (const game of games) {
     for (const gp of game.players ?? []) {
       const chars = gp.characters_played ?? []
-      const deathCharNames = new Set(
-        (gp.deaths ?? []).map(d => d.character?.name).filter(Boolean),
-      )
+      const deathsByChar = new Map()
+      for (const d of gp.deaths ?? []) {
+        const charName = d.character?.name
+        if (charName) {
+          if (!deathsByChar.has(charName)) deathsByChar.set(charName, [])
+          deathsByChar.get(charName).push(d)
+        }
+      }
       chars.forEach((char) => {
         const row = ensure(char)
         row.games += 1
-        if (deathCharNames.has(char)) row.deaths += 1
+        const charDeaths = deathsByChar.get(char) ?? []
+        if (charDeaths.length > 0) row.deaths += 1
+        for (const d of charDeaths) {
+          const typeName = d.death_type?.name
+          if (typeName) {
+            row.deathTypeCounts.set(typeName, (row.deathTypeCounts.get(typeName) ?? 0) + 1)
+          }
+        }
       })
       if (gp.is_winner && gp.winning_character) {
         ensure(gp.winning_character).wins += 1
@@ -74,12 +87,23 @@ export function computeCharacterStats(games, allCharacters) {
   const expansionByName = new Map(
     (allCharacters ?? []).map((c) => [c.name, c.expansion]),
   )
-  const rows = Array.from(stats.values()).map((row) => ({
-    ...row,
-    expansion: expansionByName.get(row.character) ?? 'NA',
-    winRate: row.games > 0 ? row.wins / row.games : 0,
-    deathRate: row.games > 0 ? row.deaths / row.games : 0,
-  }))
+  const rows = Array.from(stats.values()).map((row) => {
+    let topDeath = 'NA'
+    let maxCount = 0
+    for (const [type, count] of row.deathTypeCounts) {
+      if (count > maxCount) {
+        maxCount = count
+        topDeath = `${type} (${count})`
+      }
+    }
+    return {
+      ...row,
+      expansion: expansionByName.get(row.character) ?? 'NA',
+      winRate: row.games > 0 ? row.wins / row.games : 0,
+      deathRate: row.games > 0 ? row.deaths / row.games : 0,
+      topDeath,
+    }
+  })
 
   // Characters that exist in seed but were never played get a zero row
   for (const c of allCharacters ?? []) {
@@ -92,6 +116,7 @@ export function computeCharacterStats(games, allCharacters) {
         deaths: 0,
         winRate: 0,
         deathRate: 0,
+        topDeath: 'NA',
       })
     }
   }
@@ -119,6 +144,7 @@ export function computeEndingStats(games) {
         playerWins: 0,
         talismanWins: 0,
         winningCharCounts: new Map(),
+        deathTypeCounts: new Map(),
       })
     }
     const row = stats.get(id)
@@ -137,6 +163,14 @@ export function computeEndingStats(games) {
     } else {
       row.talismanWins += 1
     }
+    for (const gp of game.players ?? []) {
+      for (const d of gp.deaths ?? []) {
+        const typeName = d.death_type?.name
+        if (typeName) {
+          row.deathTypeCounts.set(typeName, (row.deathTypeCounts.get(typeName) ?? 0) + 1)
+        }
+      }
+    }
   }
 
   return Array.from(stats.values()).map((row) => {
@@ -148,6 +182,15 @@ export function computeEndingStats(games) {
         topCount = count
       }
     }
+    let topDeathType = null
+    let topDeathCount = 0
+    for (const [type, count] of row.deathTypeCounts.entries()) {
+      if (count > topDeathCount) {
+        topDeathType = type
+        topDeathCount = count
+      }
+    }
+
     return {
       id: row.id,
       name: row.name,
@@ -157,6 +200,7 @@ export function computeEndingStats(games) {
       playerWinRate: row.times > 0 ? row.playerWins / row.times : 0,
       talismanWinRate: row.times > 0 ? row.talismanWins / row.times : 0,
       topWinningCharacter: topChar ? `${topChar} (${topCount})` : 'NA',
+      topDeath: topDeathType ? `${topDeathType} (${topDeathCount})` : 'NA',
     }
   })
 }

--- a/src/lib/statsAggregations.js
+++ b/src/lib/statsAggregations.js
@@ -57,11 +57,13 @@ export function computeCharacterStats(games, allCharacters) {
   for (const game of games) {
     for (const gp of game.players ?? []) {
       const chars = gp.characters_played ?? []
-      const deaths = Math.min(gp.total_deaths ?? 0, chars.length)
-      chars.forEach((char, idx) => {
+      const deathCharNames = new Set(
+        (gp.deaths ?? []).map(d => d.character?.name).filter(Boolean),
+      )
+      chars.forEach((char) => {
         const row = ensure(char)
         row.games += 1
-        if (idx < deaths) row.deaths += 1
+        if (deathCharNames.has(char)) row.deaths += 1
       })
       if (gp.is_winner && gp.winning_character) {
         ensure(gp.winning_character).wins += 1
@@ -157,6 +159,71 @@ export function computeEndingStats(games) {
       topWinningCharacter: topChar ? `${topChar} (${topCount})` : 'NA',
     }
   })
+}
+
+// ── Deaths ─────────────────────────────────────────────────
+// Per death-type aggregation across all games.
+export function computeDeathTypeStats(games) {
+  const stats = new Map()
+  let total = 0
+
+  for (const game of games) {
+    for (const gp of game.players ?? []) {
+      for (const d of gp.deaths ?? []) {
+        const name = d.death_type?.name ?? 'Unknown'
+        const row = stats.get(name) ?? { deathType: name, count: 0 }
+        row.count += 1
+        stats.set(name, row)
+        total += 1
+      }
+    }
+  }
+
+  return Array.from(stats.values()).map((row) => ({
+    ...row,
+    pctOfAllDeaths: total > 0 ? row.count / total : 0,
+  }))
+}
+
+// Per-player death breakdown by type.
+export function computePlayerDeathBreakdown(games) {
+  const stats = new Map()
+
+  for (const game of games) {
+    for (const gp of game.players ?? []) {
+      const playerName = gp.player?.name ?? 'Unknown'
+      for (const d of gp.deaths ?? []) {
+        const deathType = d.death_type?.name ?? 'Unknown'
+        const key = `${playerName}::${deathType}`
+        const row = stats.get(key) ?? { playerName, deathType, count: 0 }
+        row.count += 1
+        stats.set(key, row)
+      }
+    }
+  }
+
+  return Array.from(stats.values())
+}
+
+// PVP kill leaderboard: who kills who.
+export function computePvpKillLeaderboard(games) {
+  const stats = new Map()
+
+  for (const game of games) {
+    for (const gp of game.players ?? []) {
+      for (const d of gp.deaths ?? []) {
+        if (!d.killed_by) continue
+        const killer = d.killed_by.name ?? 'Unknown'
+        const victim = gp.player?.name ?? 'Unknown'
+        const key = `${killer}::${victim}`
+        const row = stats.get(key) ?? { killer, victim, count: 0 }
+        row.count += 1
+        stats.set(key, row)
+      }
+    }
+  }
+
+  return Array.from(stats.values())
 }
 
 // ── Expansion events ────────────────────────────────────────

--- a/src/lib/statsHelpers.js
+++ b/src/lib/statsHelpers.js
@@ -1,6 +1,7 @@
-export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) {
+export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map(), deathsRaw = []) {
   const byPlayer = new Map()
   const gameHasWinner = new Map()
+  const playerNames = new Map()
 
   for (const gp of gamePlayers) {
     if (gp.game_id) {
@@ -8,6 +9,7 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) 
     }
     if (!gp.player) continue
     const pid = gp.player.id
+    playerNames.set(pid, gp.player.name)
     if (!byPlayer.has(pid)) {
       byPlayer.set(pid, {
         id: pid,
@@ -17,16 +19,39 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) 
         total_deaths: 0,
         total_toad_times: 0,
         character_counts: new Map(),
+        character_wins: new Map(),
+        games_with_zero_deaths: 0,
+        game_results: [],
       })
     }
     const row = byPlayer.get(pid)
     row.games_played += 1
     if (gp.is_winner) row.wins += 1
     row.total_deaths += gp.total_deaths ?? 0
+    if ((gp.total_deaths ?? 0) === 0) row.games_with_zero_deaths += 1
     row.total_toad_times += gp.total_toad_times ?? 0
     for (const c of gp.characters_played ?? []) {
       row.character_counts.set(c, (row.character_counts.get(c) ?? 0) + 1)
     }
+    if (gp.is_winner && gp.winning_character) {
+      row.character_wins.set(
+        gp.winning_character,
+        (row.character_wins.get(gp.winning_character) ?? 0) + 1,
+      )
+    }
+    row.game_results.push({
+      date: gp.game?.created_at ?? '',
+      isWin: !!gp.is_winner,
+    })
+  }
+
+  // Nemesis: per player, which other player killed them the most
+  const killsByVictim = new Map()
+  for (const d of deathsRaw) {
+    if (!d.killed_by_player_id || !d.player_id) continue
+    const victimKills = killsByVictim.get(d.player_id) ?? new Map()
+    victimKills.set(d.killed_by_player_id, (victimKills.get(d.killed_by_player_id) ?? 0) + 1)
+    killsByVictim.set(d.player_id, victimKills)
   }
 
   const totalGames = gameHasWinner.size
@@ -42,6 +67,7 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) 
           mostPlayed = char
         }
       }
+
       let topDeath = null
       const typeCounts = deathTypesByPlayer.get(row.id)
       if (typeCounts) {
@@ -51,6 +77,82 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) 
             maxDeath = count
             topDeath = `${type} (${count})`
           }
+        }
+      }
+
+      // Best character by win rate (min 2 games), fallback to most wins
+      let bestCharacter = null
+      let bestCharWinRate = -1
+      let bestCharGames = 0
+      for (const [char, gamesCount] of row.character_counts) {
+        if (gamesCount < 2) continue
+        const charWins = row.character_wins.get(char) ?? 0
+        const rate = charWins / gamesCount
+        if (rate > bestCharWinRate || (rate === bestCharWinRate && gamesCount > bestCharGames)) {
+          bestCharacter = char
+          bestCharWinRate = rate
+          bestCharGames = gamesCount
+        }
+      }
+      if (!bestCharacter) {
+        let maxWins = 0
+        for (const [char, wins] of row.character_wins) {
+          if (wins > maxWins) {
+            maxWins = wins
+            bestCharacter = char
+            const played = row.character_counts.get(char) ?? 0
+            bestCharWinRate = played > 0 ? wins / played : 0
+          }
+        }
+      }
+
+      // Streaks
+      const results = row.game_results.sort((a, b) => a.date.localeCompare(b.date))
+      let bestWinStreak = 0
+      let longestLoseStreak = 0
+      let winRun = 0
+      let loseRun = 0
+      for (const r of results) {
+        if (r.isWin) {
+          winRun += 1
+          loseRun = 0
+          if (winRun > bestWinStreak) bestWinStreak = winRun
+        } else {
+          loseRun += 1
+          winRun = 0
+          if (loseRun > longestLoseStreak) longestLoseStreak = loseRun
+        }
+      }
+      let currentStreak = '—'
+      if (results.length > 0) {
+        const lastIsWin = results[results.length - 1].isWin
+        let count = 1
+        for (let i = results.length - 2; i >= 0; i--) {
+          if (results[i].isWin === lastIsWin) count += 1
+          else break
+        }
+        currentStreak = `${lastIsWin ? 'W' : 'L'}${count}`
+      }
+
+      // Survival rate
+      const survivalRate = row.games_played > 0
+        ? (row.games_with_zero_deaths / row.games_played) * 100
+        : 0
+
+      // Nemesis
+      let nemesis = '—'
+      const victimKills = killsByVictim.get(row.id)
+      if (victimKills) {
+        let maxKills = 0
+        let nemesisId = null
+        for (const [killerId, count] of victimKills) {
+          if (count > maxKills) {
+            maxKills = count
+            nemesisId = killerId
+          }
+        }
+        if (nemesisId) {
+          nemesis = `${playerNames.get(nemesisId) ?? 'Unknown'} (${maxKills})`
         }
       }
 
@@ -66,6 +168,14 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) 
         avg_toad_times: row.games_played > 0 ? row.total_toad_times / row.games_played : 0,
         most_played: mostPlayed,
         top_death: topDeath ?? '—',
+        best_win_streak: bestWinStreak,
+        longest_lose_streak: longestLoseStreak,
+        current_streak: currentStreak,
+        survival_rate: survivalRate,
+        best_character: bestCharacter
+          ? `${bestCharacter} (${(bestCharWinRate * 100).toFixed(0)}%)`
+          : '—',
+        nemesis,
       }
     })
 
@@ -82,6 +192,12 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) 
       avg_toad_times: 0,
       most_played: '—',
       top_death: '—',
+      best_win_streak: 0,
+      longest_lose_streak: 0,
+      current_streak: '—',
+      survival_rate: 0,
+      best_character: '—',
+      nemesis: '—',
     })
   }
 

--- a/src/lib/statsHelpers.js
+++ b/src/lib/statsHelpers.js
@@ -1,4 +1,4 @@
-export function computeLeaderboard(gamePlayers) {
+export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map()) {
   const byPlayer = new Map()
   const gameHasWinner = new Map()
 
@@ -42,6 +42,18 @@ export function computeLeaderboard(gamePlayers) {
           mostPlayed = char
         }
       }
+      let topDeath = null
+      const typeCounts = deathTypesByPlayer.get(row.id)
+      if (typeCounts) {
+        let maxDeath = 0
+        for (const [type, count] of typeCounts) {
+          if (count > maxDeath) {
+            maxDeath = count
+            topDeath = `${type} (${count})`
+          }
+        }
+      }
+
       return {
         id: row.id,
         name: row.name,
@@ -53,6 +65,7 @@ export function computeLeaderboard(gamePlayers) {
         total_toad_times: row.total_toad_times,
         avg_toad_times: row.games_played > 0 ? row.total_toad_times / row.games_played : 0,
         most_played: mostPlayed,
+        top_death: topDeath ?? '—',
       }
     })
 
@@ -68,6 +81,7 @@ export function computeLeaderboard(gamePlayers) {
       total_toad_times: 0,
       avg_toad_times: 0,
       most_played: '—',
+      top_death: '—',
     })
   }
 

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -25,7 +25,11 @@ export default function EditGame() {
     playerData: game.players.reduce((acc, p) => {
       acc[p.player.id] = {
         characters_played: p.characters_played,
-        total_deaths: p.total_deaths,
+        deaths: (p.deaths ?? []).map(d => ({
+          death_type_id: d.death_type?.id ?? '',
+          character_id: d.character?.id ?? '',
+          killed_by_player_id: d.killed_by?.id ?? null,
+        })),
         total_toad_times: p.total_toad_times ?? 0,
         is_winner: p.is_winner,
       }

--- a/src/pages/GameDetail.jsx
+++ b/src/pages/GameDetail.jsx
@@ -161,6 +161,20 @@ export default function GameDetail() {
                   )}
                 </span>
               </div>
+              {(gp.deaths ?? []).length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mb-3">
+                  {gp.deaths.map((d, i) => (
+                    <span
+                      key={d.id ?? i}
+                      className="px-2.5 py-0.5 rounded-full text-xs font-body border border-danger/20 bg-danger/5 text-danger/80"
+                    >
+                      {d.character?.name && <>{d.character.name} &middot; </>}
+                      {d.death_type?.name ?? 'Unknown'}
+                      {d.killed_by && <> by {d.killed_by.name}</>}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div className="flex flex-wrap gap-2">
                 {gp.characters_played.map((char, idx) => (
                   <span key={idx} className="inline-flex items-center gap-1.5">

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -79,7 +79,7 @@ export default function HighscoresBoard() {
   const { data: records = [], error } = useHighscoreRecords()
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-8 animate-fade-up">
+      <div className="mb-8 animate-fade-up text-center">
         <h1 className="font-heading text-3xl text-parchment tracking-wide">Highscores</h1>
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -1,17 +1,25 @@
 import { useState } from 'react'
 import { useLeaderboardStats } from '../hooks/useLeaderboardStats'
 
+const TALISMAN_SHOW = new Set(['name', 'games_played', 'wins', 'win_rate'])
+
 const COLUMNS = [
   { key: 'name', label: 'Player', align: 'left' },
   { key: 'games_played', label: 'Games', align: 'center' },
   { key: 'wins', label: 'Wins', align: 'center' },
   { key: 'win_rate', label: 'Win %', align: 'center', format: v => `${v.toFixed(1)}%` },
+  { key: 'best_win_streak', label: 'Best W Streak', align: 'center' },
+  { key: 'longest_lose_streak', label: 'Worst L Streak', align: 'center' },
+  { key: 'current_streak', label: 'Streak', align: 'center' },
   { key: 'total_deaths', label: 'Deaths', align: 'center' },
   { key: 'avg_deaths', label: 'Avg Deaths', align: 'center', format: v => v.toFixed(2) },
+  { key: 'survival_rate', label: 'Survival %', align: 'center', format: v => `${v.toFixed(1)}%` },
   { key: 'total_toad_times', label: 'Toads', align: 'center' },
   { key: 'avg_toad_times', label: 'Avg Toads', align: 'center', format: v => v.toFixed(2) },
   { key: 'most_played', label: 'Most Played', align: 'left' },
+  { key: 'best_character', label: 'Best Character', align: 'left' },
   { key: 'top_death', label: 'Top Death', align: 'left' },
+  { key: 'nemesis', label: 'Nemesis', align: 'left' },
 ]
 
 function SortIcon({ active, direction }) {
@@ -44,8 +52,8 @@ export default function Leaderboard() {
   }
 
   return (
-    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-8 animate-fade-up">
+    <div className="max-w-[1600px] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-8 animate-fade-up text-center">
         <h1 className="font-heading text-3xl text-parchment tracking-wide">Leaderboard</h1>
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
@@ -58,13 +66,13 @@ export default function Leaderboard() {
       )}
 
       {rows.length === 0 ? (
-        <p className="text-muted text-sm font-body italic">No stats yet. Log a game to populate the leaderboard.</p>
+        <p className="text-muted text-sm font-body italic text-center">No stats yet. Log a game to populate the leaderboard.</p>
       ) : (
       <>
       {/* Desktop table */}
       <div className="hidden md:block animate-fade-up delay-2">
-        <div className="bg-surface border border-gold-dim/15 rounded-xl overflow-hidden">
-          <table className="w-full">
+        <div className="bg-surface border border-gold-dim/15 rounded-xl overflow-hidden overflow-x-auto">
+          <table className="w-full min-w-[1200px]">
             <thead>
               <tr className="border-b border-gold-dim/20">
                 <th className="w-10 px-4 py-3.5 text-center text-xs font-heading text-muted tracking-wider">#</th>
@@ -93,18 +101,23 @@ export default function Leaderboard() {
                       {idx + 1}
                     </span>
                   </td>
-                  {COLUMNS.map(col => (
-                    <td
-                      key={col.key}
-                      className={`px-4 py-3.5 font-body text-sm ${col.align === 'center' ? 'text-center' : 'text-left'} ${
-                        col.key === 'name' ? 'font-heading text-parchment tracking-wide' :
-                        col.key === 'win_rate' ? 'text-gold/80' :
-                        'text-parchment/70'
-                      }`}
-                    >
-                      {col.format ? col.format(player[col.key]) : player[col.key]}
-                    </td>
-                  ))}
+                  {COLUMNS.map(col => {
+                    const isTalisman = player.id === '__talisman__'
+                    const showX = isTalisman && !TALISMAN_SHOW.has(col.key)
+                    return (
+                      <td
+                        key={col.key}
+                        className={`px-4 py-3.5 font-body text-sm ${col.align === 'center' ? 'text-center' : 'text-left'} ${
+                          showX ? 'text-muted/40' :
+                          col.key === 'name' ? 'font-heading text-parchment tracking-wide' :
+                          col.key === 'win_rate' ? 'text-gold/80' :
+                          'text-parchment/70'
+                        }`}
+                      >
+                        {showX ? 'X' : col.format ? col.format(player[col.key]) : player[col.key]}
+                      </td>
+                    )
+                  })}
                 </tr>
               ))}
             </tbody>
@@ -125,40 +138,73 @@ export default function Leaderboard() {
               </div>
               <span className="text-gold font-heading text-sm">{player.win_rate.toFixed(1)}% WR</span>
             </div>
-            <div className="grid grid-cols-3 gap-y-2 text-sm font-body">
-              <div>
-                <span className="text-muted block text-xs">Games</span>
-                <span className="text-parchment/80">{player.games_played}</span>
+            {player.id === '__talisman__' ? (
+              <div className="grid grid-cols-3 gap-y-2 text-sm font-body">
+                <div>
+                  <span className="text-muted block text-xs">Games</span>
+                  <span className="text-parchment/80">{player.games_played}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Wins</span>
+                  <span className="text-parchment/80">{player.wins}</span>
+                </div>
               </div>
-              <div>
-                <span className="text-muted block text-xs">Wins</span>
-                <span className="text-parchment/80">{player.wins}</span>
+            ) : (
+              <div className="grid grid-cols-3 gap-y-2 text-sm font-body">
+                <div>
+                  <span className="text-muted block text-xs">Games</span>
+                  <span className="text-parchment/80">{player.games_played}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Wins</span>
+                  <span className="text-parchment/80">{player.wins}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Streak</span>
+                  <span className="text-parchment/80">{player.current_streak}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Best W Streak</span>
+                  <span className="text-parchment/80">{player.best_win_streak}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Worst L Streak</span>
+                  <span className="text-parchment/80">{player.longest_lose_streak}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Survival %</span>
+                  <span className="text-parchment/80">{player.survival_rate.toFixed(1)}%</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Deaths</span>
+                  <span className="text-parchment/80">{player.total_deaths}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Avg Deaths</span>
+                  <span className="text-parchment/80">{player.avg_deaths.toFixed(2)}</span>
+                </div>
+                <div>
+                  <span className="text-muted block text-xs">Toads</span>
+                  <span className="text-parchment/80">{player.total_toad_times}</span>
+                </div>
+                <div className="col-span-3">
+                  <span className="text-muted block text-xs">Most Played</span>
+                  <span className="text-parchment/80">{player.most_played}</span>
+                </div>
+                <div className="col-span-3">
+                  <span className="text-muted block text-xs">Best Character</span>
+                  <span className="text-parchment/80">{player.best_character}</span>
+                </div>
+                <div className="col-span-3">
+                  <span className="text-muted block text-xs">Top Death</span>
+                  <span className="text-parchment/80">{player.top_death}</span>
+                </div>
+                <div className="col-span-3">
+                  <span className="text-muted block text-xs">Nemesis</span>
+                  <span className="text-parchment/80">{player.nemesis}</span>
+                </div>
               </div>
-              <div>
-                <span className="text-muted block text-xs">Deaths</span>
-                <span className="text-parchment/80">{player.total_deaths}</span>
-              </div>
-              <div>
-                <span className="text-muted block text-xs">Avg Deaths</span>
-                <span className="text-parchment/80">{player.avg_deaths.toFixed(2)}</span>
-              </div>
-              <div>
-                <span className="text-muted block text-xs">Toads</span>
-                <span className="text-parchment/80">{player.total_toad_times}</span>
-              </div>
-              <div>
-                <span className="text-muted block text-xs">Avg Toads</span>
-                <span className="text-parchment/80">{player.avg_toad_times.toFixed(2)}</span>
-              </div>
-              <div className="col-span-3">
-                <span className="text-muted block text-xs">Most Played</span>
-                <span className="text-parchment/80">{player.most_played}</span>
-              </div>
-              <div className="col-span-3">
-                <span className="text-muted block text-xs">Top Death</span>
-                <span className="text-parchment/80">{player.top_death}</span>
-              </div>
-            </div>
+            )}
           </div>
         ))}
       </div>

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -11,6 +11,7 @@ const COLUMNS = [
   { key: 'total_toad_times', label: 'Toads', align: 'center' },
   { key: 'avg_toad_times', label: 'Avg Toads', align: 'center', format: v => v.toFixed(2) },
   { key: 'most_played', label: 'Most Played', align: 'left' },
+  { key: 'top_death', label: 'Top Death', align: 'left' },
 ]
 
 function SortIcon({ active, direction }) {
@@ -152,6 +153,10 @@ export default function Leaderboard() {
               <div className="col-span-3">
                 <span className="text-muted block text-xs">Most Played</span>
                 <span className="text-parchment/80">{player.most_played}</span>
+              </div>
+              <div className="col-span-3">
+                <span className="text-muted block text-xs">Top Death</span>
+                <span className="text-parchment/80">{player.top_death}</span>
               </div>
             </div>
           </div>

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -471,7 +471,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
 
   return (
     <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-6 animate-fade-up">
+      <div className="mb-6 animate-fade-up text-center">
         <h1 className="font-heading text-3xl text-parchment tracking-wide">
           {isEditing ? 'Edit Game' : 'Log a Game'}
         </h1>

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -7,6 +7,7 @@ import { useAddPlayer } from '../hooks/useAddPlayer'
 import { useLogGame } from '../hooks/useLogGame'
 import { useUpdateGame } from '../hooks/useUpdateGame'
 import { useDeleteGame } from '../hooks/useDeleteGame'
+import { useDeathTypes } from '../hooks/useDeathTypes'
 
 const HIGHSCORE_CATEGORIES = [
   { key: 'most_gold', label: 'Most Gold' },
@@ -102,6 +103,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
   const { data: allPlayers = [] } = usePlayers()
   const { data: allCharacters = [] } = useCharacters()
   const { data: allEndings = [] } = useEndings()
+  const { data: allDeathTypes = [] } = useDeathTypes()
   const addPlayer = useAddPlayer()
   const logGame = useLogGame()
   const updateGame = useUpdateGame()
@@ -118,7 +120,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
       const playerData = { ...prev.playerData }
       const expansionEvents = { ...prev.expansionEvents }
       if (!exists) {
-        playerData[playerId] = { characters_played: [], total_deaths: 0, total_toad_times: 0, is_winner: false }
+        playerData[playerId] = { characters_played: [], deaths: [], total_toad_times: 0, is_winner: false }
         expansionEvents[playerId] = emptyPlayerEvents()
       } else {
         delete playerData[playerId]
@@ -166,6 +168,57 @@ export default function LogGame({ initialData, isEditing, gameId }) {
       'characters_played',
       form.playerData[playerId].characters_played.filter((_, i) => i !== idx),
     )
+  }
+
+  const pvpDeathTypeId = allDeathTypes.find(dt => dt.name === 'PVP')?.id
+
+  const addDeath = (playerId) => {
+    setForm(prev => {
+      const chars = prev.playerData[playerId]?.characters_played ?? []
+      const autoCharId = chars.length === 1
+        ? allCharacters.find(c => c.name === chars[0])?.id ?? ''
+        : ''
+      return {
+        ...prev,
+        playerData: {
+          ...prev.playerData,
+          [playerId]: {
+            ...prev.playerData[playerId],
+            deaths: [...(prev.playerData[playerId]?.deaths ?? []), { death_type_id: '', character_id: autoCharId, killed_by_player_id: null }],
+          },
+        },
+      }
+    })
+  }
+
+  const updateDeath = (playerId, idx, field, value) => {
+    setForm(prev => {
+      const deaths = [...(prev.playerData[playerId]?.deaths ?? [])]
+      deaths[idx] = { ...deaths[idx], [field]: value }
+      if (field === 'death_type_id' && value !== pvpDeathTypeId) {
+        deaths[idx].killed_by_player_id = null
+      }
+      return {
+        ...prev,
+        playerData: {
+          ...prev.playerData,
+          [playerId]: { ...prev.playerData[playerId], deaths },
+        },
+      }
+    })
+  }
+
+  const removeDeath = (playerId, idx) => {
+    setForm(prev => ({
+      ...prev,
+      playerData: {
+        ...prev.playerData,
+        [playerId]: {
+          ...prev.playerData[playerId],
+          deaths: (prev.playerData[playerId]?.deaths ?? []).filter((_, i) => i !== idx),
+        },
+      },
+    }))
   }
 
   const addHighscoreEntry = (category) => {
@@ -303,8 +356,31 @@ export default function LogGame({ initialData, isEditing, gameId }) {
     if (!pd) return false
     const n = pd.characters_played?.length ?? 0
     if (n === 0) return false
-    const d = Number(pd.total_deaths ?? 0)
+    const d = pd.deaths?.length ?? 0
     return d !== n && d !== n - 1
+  })
+  const playersWithIncompleteDeaths = form.players.filter(id => {
+    const pd = form.playerData[id]
+    if (!pd) return false
+    return (pd.deaths ?? []).some(d =>
+      !d.death_type_id || !d.character_id || (d.death_type_id === pvpDeathTypeId && !d.killed_by_player_id),
+    )
+  })
+  const playersWithOverkilledChars = form.players.filter(id => {
+    const pd = form.playerData[id]
+    if (!pd) return false
+    const chars = pd.characters_played ?? []
+    const deaths = pd.deaths ?? []
+    const playCounts = {}
+    for (const name of chars) {
+      const charId = allCharacters.find(c => c.name === name)?.id
+      if (charId) playCounts[charId] = (playCounts[charId] ?? 0) + 1
+    }
+    const deathCounts = {}
+    for (const d of deaths) {
+      if (d.character_id) deathCounts[d.character_id] = (deathCounts[d.character_id] ?? 0) + 1
+    }
+    return Object.entries(deathCounts).some(([charId, count]) => count > (playCounts[charId] ?? 0))
   })
   const step1Errors = {
     title: !form.title?.trim()
@@ -320,7 +396,11 @@ export default function LogGame({ initialData, isEditing, gameId }) {
       : null,
     deaths: playersWithInvalidDeaths.length > 0
       ? 'Total deaths must equal characters played or one less'
-      : null,
+      : playersWithIncompleteDeaths.length > 0
+        ? 'Every death must have a type and character, and PVP deaths need a killer'
+        : playersWithOverkilledChars.length > 0
+          ? 'A character can\'t die more times than it was played'
+          : null,
   }
   const step1HasErrors = Object.values(step1Errors).some(Boolean)
 
@@ -626,32 +706,100 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                       </div>
 
                       {/* Deaths & Toad times */}
-                      <div className="mb-4 flex gap-4">
-                        <div>
-                          <label className="block text-sm font-body text-parchment/70 mb-1.5">Total Deaths</label>
-                          <input
-                            type="number"
-                            min="0"
-                            className="input-field w-24"
-                            value={data.total_deaths}
-                            onChange={e => updatePlayerData(player.id, 'total_deaths', parseInt(e.target.value) || 0)}
-                          />
-                          {step1Attempted && playersWithInvalidDeaths.includes(player.id) && (
-                            <p className="text-danger text-xs mt-1.5 font-body">
-                              Must be {Math.max(0, data.characters_played.length - 1)} or {data.characters_played.length}
-                            </p>
-                          )}
+                      <div className="mb-4">
+                        <div className="flex items-center justify-between mb-2">
+                          <label className="block text-sm font-body text-parchment/70">
+                            Deaths ({(data.deaths?.length ?? 0)})
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => addDeath(player.id)}
+                            className="text-xs font-body text-teal-light hover:text-teal border border-teal/30 hover:border-teal/60 hover:bg-teal/5 px-2.5 py-1 rounded-md transition-colors"
+                          >
+                            + Add Death
+                          </button>
                         </div>
-                        <div>
-                          <label className="block text-sm font-body text-parchment/70 mb-1.5">Times Toadified</label>
-                          <input
-                            type="number"
-                            min="0"
-                            className="input-field w-24"
-                            value={data.total_toad_times ?? 0}
-                            onChange={e => updatePlayerData(player.id, 'total_toad_times', Math.max(0, parseInt(e.target.value) || 0))}
-                          />
-                        </div>
+                        {(data.deaths ?? []).length > 0 && (
+                          <div className="space-y-2">
+                            {(data.deaths ?? []).map((death, idx) => (
+                              <div key={idx} className="flex flex-wrap items-center gap-2">
+                                {data.characters_played.length > 1 && (
+                                  <select
+                                    className="input-field text-sm flex-1 min-w-[120px]"
+                                    value={death.character_id || ''}
+                                    onChange={e => updateDeath(player.id, idx, 'character_id', e.target.value)}
+                                  >
+                                    <option value="">Character...</option>
+                                    {data.characters_played.map((charName, ci) => {
+                                      const charObj = allCharacters.find(c => c.name === charName)
+                                      return charObj ? (
+                                        <option key={`${charObj.id}-${ci}`} value={charObj.id}>{charName}</option>
+                                      ) : null
+                                    })}
+                                  </select>
+                                )}
+                                <select
+                                  className="input-field text-sm flex-1 min-w-[140px]"
+                                  value={death.death_type_id}
+                                  onChange={e => updateDeath(player.id, idx, 'death_type_id', e.target.value)}
+                                >
+                                  <option value="">Death type...</option>
+                                  {allDeathTypes.map(dt => (
+                                    <option key={dt.id} value={dt.id}>{dt.name}</option>
+                                  ))}
+                                </select>
+                                {death.death_type_id === pvpDeathTypeId && (
+                                  <select
+                                    className="input-field text-sm flex-1 min-w-[120px]"
+                                    value={death.killed_by_player_id || ''}
+                                    onChange={e => updateDeath(player.id, idx, 'killed_by_player_id', e.target.value || null)}
+                                  >
+                                    <option value="">Killed by...</option>
+                                    {form.players
+                                      .filter(pid => pid !== player.id)
+                                      .map(pid => allPlayers.find(p => p.id === pid))
+                                      .filter(Boolean)
+                                      .map(p => (
+                                        <option key={p.id} value={p.id}>{p.name}</option>
+                                      ))}
+                                  </select>
+                                )}
+                                <button
+                                  type="button"
+                                  onClick={() => removeDeath(player.id, idx)}
+                                  className="text-lg leading-none text-muted hover:text-danger transition-colors p-1 hover:bg-danger/10 rounded-md"
+                                >
+                                  &times;
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        {step1Attempted && playersWithInvalidDeaths.includes(player.id) && (
+                          <p className="text-danger text-xs mt-1.5 font-body">
+                            Must have {Math.max(0, data.characters_played.length - 1)} or {data.characters_played.length} death{data.characters_played.length !== 1 ? 's' : ''}
+                          </p>
+                        )}
+                        {step1Attempted && playersWithIncompleteDeaths.includes(player.id) && (
+                          <p className="text-danger text-xs mt-1.5 font-body">
+                            Every death needs a type and character, and PVP deaths need a killer
+                          </p>
+                        )}
+                        {step1Attempted && playersWithOverkilledChars.includes(player.id) && (
+                          <p className="text-danger text-xs mt-1.5 font-body">
+                            A character can&apos;t die more times than it was played
+                          </p>
+                        )}
+                      </div>
+                      <div className="mb-4">
+                        <label className="block text-sm font-body text-parchment/70 mb-1.5">Times Toadified</label>
+                        <input
+                          type="number"
+                          min="0"
+                          className="input-field w-24"
+                          value={data.total_toad_times ?? 0}
+                          onChange={e => updatePlayerData(player.id, 'total_toad_times', Math.max(0, parseInt(e.target.value) || 0))}
+                        />
                       </div>
 
                       {/* Expansion Events */}
@@ -930,7 +1078,14 @@ export default function LogGame({ initialData, isEditing, gameId }) {
                         </span>
                         <span className="text-parchment/60">
                           {data.characters_played.length > 0 ? data.characters_played.join(' \u2192 ') : 'No characters'}
-                          {' \u00b7 '}{data.total_deaths} death{data.total_deaths !== 1 ? 's' : ''}
+                          {' \u00b7 '}{data.deaths?.length ?? 0} death{(data.deaths?.length ?? 0) !== 1 ? 's' : ''}
+                          {(data.deaths?.length ?? 0) > 0 && (
+                            <> ({(data.deaths ?? []).map(d => {
+                              const typeName = allDeathTypes.find(dt => dt.id === d.death_type_id)?.name || '?'
+                              const charName = allCharacters.find(c => c.id === d.character_id)?.name
+                              return charName ? `${charName}: ${typeName}` : typeName
+                            }).join(', ')})</>
+                          )}
                           {(data.total_toad_times ?? 0) > 0 && (
                             <>{' \u00b7 '}{data.total_toad_times} toad{data.total_toad_times !== 1 ? 's' : ''}</>
                           )}

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -7,12 +7,16 @@ import {
   computeCharacterStats,
   computeEndingStats,
   computeExpansionEventStats,
+  computeDeathTypeStats,
+  computePlayerDeathBreakdown,
+  computePvpKillLeaderboard,
 } from '../lib/statsAggregations'
 
 const TABS = [
   { key: 'characters', label: 'Characters' },
   { key: 'endings', label: 'Endings' },
   { key: 'expansions', label: 'Expansions' },
+  { key: 'deaths', label: 'Deaths' },
 ]
 
 function SortIcon({ active, direction }) {
@@ -256,6 +260,83 @@ function ExpansionsTab({ games }) {
   )
 }
 
+function DeathsTab({ games }) {
+  const deathTypeSort = useSort('count', 'desc')
+  const playerBreakdownSort = useSort('count', 'desc')
+  const pvpSort = useSort('count', 'desc')
+
+  const deathTypeRows = useMemo(() => computeDeathTypeStats(games), [games])
+  const playerBreakdownRows = useMemo(() => computePlayerDeathBreakdown(games), [games])
+  const pvpRows = useMemo(() => computePvpKillLeaderboard(games), [games])
+
+  const totalDeaths = useMemo(
+    () => deathTypeRows.reduce((sum, r) => sum + r.count, 0),
+    [deathTypeRows],
+  )
+
+  const deathTypeColumns = [
+    { key: 'deathType', label: 'Death Type', align: 'left' },
+    { key: 'count', label: 'Count', align: 'center', accent: true },
+    { key: 'pctOfAllDeaths', label: '% of Deaths', align: 'center', format: pct },
+  ]
+
+  const playerBreakdownColumns = [
+    { key: 'playerName', label: 'Player', align: 'left' },
+    { key: 'deathType', label: 'Death Type', align: 'left' },
+    { key: 'count', label: 'Count', align: 'center', accent: true },
+  ]
+
+  const pvpColumns = [
+    { key: 'killer', label: 'Killer', align: 'left' },
+    { key: 'victim', label: 'Victim', align: 'left' },
+    { key: 'count', label: 'Kills', align: 'center', accent: true },
+  ]
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap gap-3">
+        <TotalCard label="Total Deaths" value={totalDeaths} />
+      </div>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Death Type Breakdown</h3>
+        <StatsTable
+          columns={deathTypeColumns}
+          rows={deathTypeRows}
+          sort={deathTypeSort.sort}
+          sortKey={deathTypeSort.sortKey}
+          sortDir={deathTypeSort.sortDir}
+          onSort={deathTypeSort.toggle}
+          emptyMessage="No death data yet."
+        />
+      </section>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Deaths per Player</h3>
+        <StatsTable
+          columns={playerBreakdownColumns}
+          rows={playerBreakdownRows}
+          sort={playerBreakdownSort.sort}
+          sortKey={playerBreakdownSort.sortKey}
+          sortDir={playerBreakdownSort.sortDir}
+          onSort={playerBreakdownSort.toggle}
+          emptyMessage="No death data yet."
+        />
+      </section>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">PVP Kill Leaderboard</h3>
+        <StatsTable
+          columns={pvpColumns}
+          rows={pvpRows}
+          sort={pvpSort.sort}
+          sortKey={pvpSort.sortKey}
+          sortDir={pvpSort.sortDir}
+          onSort={pvpSort.toggle}
+          emptyMessage="No PVP kills recorded yet."
+        />
+      </section>
+    </div>
+  )
+}
+
 export default function Stats() {
   const [tab, setTab] = useState('characters')
   const [optionalFilter, setOptionalFilter] = useState('all')
@@ -337,6 +418,7 @@ export default function Stats() {
           {tab === 'characters' && <CharactersTab games={games} allCharacters={allCharacters} />}
           {tab === 'endings' && <EndingsTab games={games} />}
           {tab === 'expansions' && <ExpansionsTab games={games} />}
+          {tab === 'deaths' && <DeathsTab games={games} />}
         </div>
       )}
     </div>

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -110,6 +110,7 @@ function CharactersTab({ games, allCharacters }) {
     { key: 'winRate', label: 'Win %', align: 'center', format: pct, accent: true },
     { key: 'deaths', label: 'Deaths', align: 'center' },
     { key: 'deathRate', label: 'Death %', align: 'center', format: pct },
+    { key: 'topDeath', label: 'Top Death', align: 'left', sortable: false },
   ]
 
   return (
@@ -150,6 +151,7 @@ function EndingsTab({ games }) {
     { key: 'playerWinRate', label: 'Player Win %', align: 'center', format: pct, accent: true },
     { key: 'talismanWinRate', label: 'Talisman Win %', align: 'center', format: pct },
     { key: 'topWinningCharacter', label: 'Top Winner', align: 'left', sortable: false },
+    { key: 'topDeath', label: 'Top Death', align: 'left', sortable: false },
   ]
 
   return (

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -9,6 +9,7 @@ import {
   computeExpansionEventStats,
   computeDeathTypeStats,
   computePlayerDeathBreakdown,
+  computeCharacterDeathBreakdown,
   computePvpKillLeaderboard,
 } from '../lib/statsAggregations'
 
@@ -43,14 +44,14 @@ function useSort(initialKey, initialDir = 'desc') {
   return { sortKey, sortDir, toggle, sort }
 }
 
-function StatsTable({ columns, rows, sort, sortKey, sortDir, onSort, emptyMessage }) {
+function StatsTable({ columns, rows, sort, sortKey, sortDir, onSort, emptyMessage, compact }) {
   const sorted = sort(rows)
   if (sorted.length === 0) {
     return <p className="text-muted text-sm font-body italic">{emptyMessage}</p>
   }
   return (
     <div className="bg-surface border border-gold-dim/15 rounded-xl overflow-hidden overflow-x-auto">
-      <table className="w-full min-w-[640px]">
+      <table className={`w-full ${compact ? '' : 'min-w-[640px]'}`}>
         <thead>
           <tr className="border-b border-gold-dim/20">
             {columns.map(col => (
@@ -150,6 +151,7 @@ function EndingsTab({ games }) {
     { key: 'pctOfGames', label: '% Games', align: 'center', format: pct },
     { key: 'playerWinRate', label: 'Player Win %', align: 'center', format: pct, accent: true },
     { key: 'talismanWinRate', label: 'Talisman Win %', align: 'center', format: pct },
+    { key: 'avgDeathsPerGame', label: 'Avg Deaths / Game', align: 'center', format: v => v.toFixed(2) },
     { key: 'topWinningCharacter', label: 'Top Winner', align: 'left', sortable: false },
     { key: 'topDeath', label: 'Top Death', align: 'left', sortable: false },
   ]
@@ -178,20 +180,57 @@ function TotalCard({ label, value }) {
 
 function ExpansionsTab({ games }) {
   const dungeonSort = useSort('count', 'desc')
+  const dungeonPlayerSort = useSort('count', 'desc')
   const pathTotalsSort = useSort('count', 'desc')
+  const pathTotalsPlayerSort = useSort('count', 'desc')
   const pathByPathSort = useSort('count', 'desc')
+  const pathPlayerSort = useSort('count', 'desc')
   const pathSort = useSort('count', 'desc')
-  const { dungeons, paths, pathsTotals, pathsByPath, totals } = useMemo(
+  const [pathPlayer, setPathPlayer] = useState('')
+  const [pathCharacter, setPathCharacter] = useState('')
+  const { dungeons, dungeonsByPlayer, paths, pathsTotals, pathsTotalsByPlayer, pathsByPath, pathsByPlayer, totals } = useMemo(
     () => computeExpansionEventStats(games),
     [games],
   )
+
+  const pathPlayerNames = useMemo(() => {
+    const set = new Set(pathsByPlayer.map(r => r.playerName))
+    return Array.from(set).sort()
+  }, [pathsByPlayer])
+
+  const pathCharacterNames = useMemo(() => {
+    const set = new Set(paths.map(r => r.character))
+    return Array.from(set).sort()
+  }, [paths])
+
+  const filteredPathsByPlayer = useMemo(() => {
+    if (!pathPlayer) {
+      return [...pathsByPlayer].sort((a, b) => b.count - a.count).slice(0, 5)
+    }
+    return pathsByPlayer.filter(r => r.playerName === pathPlayer)
+  }, [pathsByPlayer, pathPlayer])
+
+  const filteredPathsByCharacter = useMemo(() => {
+    if (!pathCharacter) {
+      return [...paths].sort((a, b) => b.count - a.count).slice(0, 5)
+    }
+    return paths.filter(r => r.character === pathCharacter)
+  }, [paths, pathCharacter])
 
   const dungeonColumns = [
     { key: 'character', label: 'Character', align: 'left' },
     { key: 'count', label: 'Dungeons Beaten', align: 'center', accent: true },
   ]
+  const dungeonPlayerColumns = [
+    { key: 'playerName', label: 'Player', align: 'left' },
+    { key: 'count', label: 'Dungeons Beaten', align: 'center', accent: true },
+  ]
   const pathTotalsColumns = [
     { key: 'character', label: 'Character', align: 'left' },
+    { key: 'count', label: 'Paths Completed', align: 'center', accent: true },
+  ]
+  const pathTotalsPlayerColumns = [
+    { key: 'playerName', label: 'Player', align: 'left' },
     { key: 'count', label: 'Paths Completed', align: 'center', accent: true },
   ]
   const pathByPathColumns = [
@@ -210,18 +249,62 @@ function ExpansionsTab({ games }) {
         <TotalCard label="Total Dungeons Beaten" value={totals.dungeons} />
         <TotalCard label="Total Woodland Clears" value={totals.paths} />
       </div>
-      <section>
-        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Dungeons Beaten</h3>
-        <StatsTable
-          columns={dungeonColumns}
-          rows={dungeons}
-          sort={dungeonSort.sort}
-          sortKey={dungeonSort.sortKey}
-          sortDir={dungeonSort.sortDir}
-          onSort={dungeonSort.toggle}
-          emptyMessage="No dungeons beaten in this filter."
-        />
-      </section>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+        <section className="max-h-[480px] overflow-y-auto">
+          <h3 className="font-heading text-lg text-parchment tracking-wide mb-3 sticky top-0 bg-background z-10 pb-1">Dungeons Beaten per Character</h3>
+          <StatsTable
+            columns={dungeonColumns}
+            rows={dungeons}
+            sort={dungeonSort.sort}
+            sortKey={dungeonSort.sortKey}
+            sortDir={dungeonSort.sortDir}
+            onSort={dungeonSort.toggle}
+            emptyMessage="No dungeons beaten in this filter."
+            compact
+          />
+        </section>
+        <section>
+          <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Dungeons Beaten per Player</h3>
+          <StatsTable
+            columns={dungeonPlayerColumns}
+            rows={dungeonsByPlayer}
+            sort={dungeonPlayerSort.sort}
+            sortKey={dungeonPlayerSort.sortKey}
+            sortDir={dungeonPlayerSort.sortDir}
+            onSort={dungeonPlayerSort.toggle}
+            emptyMessage="No dungeons beaten in this filter."
+            compact
+          />
+        </section>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+        <section className="max-h-[480px] overflow-y-auto">
+          <h3 className="font-heading text-lg text-parchment tracking-wide mb-3 sticky top-0 bg-background z-10 pb-1">Total Paths per Character</h3>
+          <StatsTable
+            columns={pathTotalsColumns}
+            rows={pathsTotals}
+            sort={pathTotalsSort.sort}
+            sortKey={pathTotalsSort.sortKey}
+            sortDir={pathTotalsSort.sortDir}
+            onSort={pathTotalsSort.toggle}
+            emptyMessage="No paths completed in this filter."
+            compact
+          />
+        </section>
+        <section>
+          <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Total Paths per Player</h3>
+          <StatsTable
+            columns={pathTotalsPlayerColumns}
+            rows={pathsTotalsByPlayer}
+            sort={pathTotalsPlayerSort.sort}
+            sortKey={pathTotalsPlayerSort.sortKey}
+            sortDir={pathTotalsPlayerSort.sortDir}
+            onSort={pathTotalsPlayerSort.toggle}
+            emptyMessage="No paths completed in this filter."
+            compact
+          />
+        </section>
+      </div>
       <section>
         <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Total Paths by Path</h3>
         <StatsTable
@@ -232,30 +315,62 @@ function ExpansionsTab({ games }) {
           sortDir={pathByPathSort.sortDir}
           onSort={pathByPathSort.toggle}
           emptyMessage="No paths completed in this filter."
+          compact
         />
       </section>
       <section>
-        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Total Paths per Character</h3>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">
+          Woodland Paths per Player
+        </h3>
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <span className="text-xs font-body text-muted uppercase tracking-wider">Player</span>
+          <select
+            className="input-field text-sm py-1.5 w-auto"
+            value={pathPlayer}
+            onChange={e => setPathPlayer(e.target.value)}
+          >
+            <option value="">Top 5</option>
+            {pathPlayerNames.map(name => <option key={name} value={name}>{name}</option>)}
+          </select>
+        </div>
         <StatsTable
-          columns={pathTotalsColumns}
-          rows={pathsTotals}
-          sort={pathTotalsSort.sort}
-          sortKey={pathTotalsSort.sortKey}
-          sortDir={pathTotalsSort.sortDir}
-          onSort={pathTotalsSort.toggle}
-          emptyMessage="No paths completed in this filter."
+          columns={[
+            ...(!pathPlayer ? [{ key: 'playerName', label: 'Player', align: 'left' }] : []),
+            { key: 'path', label: 'Path', align: 'left' },
+            { key: 'count', label: 'Completed', align: 'center', accent: true },
+          ]}
+          rows={filteredPathsByPlayer}
+          sort={pathPlayerSort.sort}
+          sortKey={pathPlayerSort.sortKey}
+          sortDir={pathPlayerSort.sortDir}
+          onSort={pathPlayerSort.toggle}
+          emptyMessage="No paths completed by this player."
+          compact
         />
       </section>
       <section>
-        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Woodland Paths Breakdown</h3>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">
+          Woodland Paths Breakdown
+        </h3>
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <span className="text-xs font-body text-muted uppercase tracking-wider">Character</span>
+          <select
+            className="input-field text-sm py-1.5 w-auto"
+            value={pathCharacter}
+            onChange={e => setPathCharacter(e.target.value)}
+          >
+            <option value="">Top 5</option>
+            {pathCharacterNames.map(name => <option key={name} value={name}>{name}</option>)}
+          </select>
+        </div>
         <StatsTable
           columns={pathColumns}
-          rows={paths}
+          rows={filteredPathsByCharacter}
           sort={pathSort.sort}
           sortKey={pathSort.sortKey}
           sortDir={pathSort.sortDir}
           onSort={pathSort.toggle}
-          emptyMessage="No paths completed in this filter."
+          emptyMessage="No paths completed by this character."
         />
       </section>
     </div>
@@ -265,16 +380,53 @@ function ExpansionsTab({ games }) {
 function DeathsTab({ games }) {
   const deathTypeSort = useSort('count', 'desc')
   const playerBreakdownSort = useSort('count', 'desc')
+  const playerFilterSort = useSort('count', 'desc')
+  const charFilterSort = useSort('count', 'desc')
   const pvpSort = useSort('count', 'desc')
+  const [selectedPlayer, setSelectedPlayer] = useState('')
+  const [selectedCharacter, setSelectedCharacter] = useState('')
 
   const deathTypeRows = useMemo(() => computeDeathTypeStats(games), [games])
   const playerBreakdownRows = useMemo(() => computePlayerDeathBreakdown(games), [games])
+  const charBreakdownRows = useMemo(() => computeCharacterDeathBreakdown(games), [games])
   const pvpRows = useMemo(() => computePvpKillLeaderboard(games), [games])
 
   const totalDeaths = useMemo(
     () => deathTypeRows.reduce((sum, r) => sum + r.count, 0),
     [deathTypeRows],
   )
+
+  const playerNames = useMemo(() => {
+    const set = new Set(playerBreakdownRows.map(r => r.playerName))
+    return Array.from(set).sort()
+  }, [playerBreakdownRows])
+
+  const playerFilteredRows = useMemo(() => {
+    const base = selectedPlayer
+      ? playerBreakdownRows.filter(r => r.playerName === selectedPlayer)
+      : [...playerBreakdownRows].sort((a, b) => b.count - a.count).slice(0, 5)
+    const playerTotal = base.reduce((sum, r) => sum + r.count, 0)
+    return base.map(r => ({
+      ...r,
+      pctOfPlayerDeaths: playerTotal > 0 ? r.count / playerTotal : 0,
+    }))
+  }, [playerBreakdownRows, selectedPlayer])
+
+  const characterNames = useMemo(() => {
+    const set = new Set(charBreakdownRows.map(r => r.character))
+    return Array.from(set).sort()
+  }, [charBreakdownRows])
+
+  const charFilteredRows = useMemo(() => {
+    const base = selectedCharacter
+      ? charBreakdownRows.filter(r => r.character === selectedCharacter)
+      : [...charBreakdownRows].sort((a, b) => b.count - a.count).slice(0, 5)
+    const charTotal = base.reduce((sum, r) => sum + r.count, 0)
+    return base.map(r => ({
+      ...r,
+      pctOfCharDeaths: charTotal > 0 ? r.count / charTotal : 0,
+    }))
+  }, [charBreakdownRows, selectedCharacter])
 
   const deathTypeColumns = [
     { key: 'deathType', label: 'Death Type', align: 'left' },
@@ -311,18 +463,66 @@ function DeathsTab({ games }) {
           emptyMessage="No death data yet."
         />
       </section>
-      <section>
-        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Deaths per Player</h3>
-        <StatsTable
-          columns={playerBreakdownColumns}
-          rows={playerBreakdownRows}
-          sort={playerBreakdownSort.sort}
-          sortKey={playerBreakdownSort.sortKey}
-          sortDir={playerBreakdownSort.sortDir}
-          onSort={playerBreakdownSort.toggle}
-          emptyMessage="No death data yet."
-        />
-      </section>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+        <section>
+          <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Character Death Types</h3>
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <span className="text-xs font-body text-muted uppercase tracking-wider">Character</span>
+            <select
+              className="input-field text-sm py-1.5 w-auto"
+              value={selectedCharacter}
+              onChange={e => setSelectedCharacter(e.target.value)}
+            >
+              <option value="">Top 5</option>
+              {characterNames.map(name => <option key={name} value={name}>{name}</option>)}
+            </select>
+          </div>
+          <StatsTable
+            columns={[
+              ...(!selectedCharacter ? [{ key: 'character', label: 'Character', align: 'left' }] : []),
+              { key: 'deathType', label: 'Death Type', align: 'left' },
+              { key: 'count', label: 'Count', align: 'center', accent: true },
+              { key: 'pctOfCharDeaths', label: '% of Deaths', align: 'center', format: pct },
+            ]}
+            rows={charFilteredRows}
+            sort={charFilterSort.sort}
+            sortKey={charFilterSort.sortKey}
+            sortDir={charFilterSort.sortDir}
+            onSort={charFilterSort.toggle}
+            emptyMessage="No deaths recorded for this character."
+            compact
+          />
+        </section>
+        <section>
+          <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Player Death Types</h3>
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <span className="text-xs font-body text-muted uppercase tracking-wider">Player</span>
+            <select
+              className="input-field text-sm py-1.5 w-auto"
+              value={selectedPlayer}
+              onChange={e => setSelectedPlayer(e.target.value)}
+            >
+              <option value="">Top 5</option>
+              {playerNames.map(name => <option key={name} value={name}>{name}</option>)}
+            </select>
+          </div>
+          <StatsTable
+            columns={[
+              ...(!selectedPlayer ? [{ key: 'playerName', label: 'Player', align: 'left' }] : []),
+              { key: 'deathType', label: 'Death Type', align: 'left' },
+              { key: 'count', label: 'Count', align: 'center', accent: true },
+              { key: 'pctOfPlayerDeaths', label: '% of Deaths', align: 'center', format: pct },
+            ]}
+            rows={playerFilteredRows}
+            sort={playerFilterSort.sort}
+            sortKey={playerFilterSort.sortKey}
+            sortDir={playerFilterSort.sortDir}
+            onSort={playerFilterSort.toggle}
+            emptyMessage="No deaths recorded for this player."
+            compact
+          />
+        </section>
+      </div>
       <section>
         <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">PVP Kill Leaderboard</h3>
         <StatsTable
@@ -333,6 +533,18 @@ function DeathsTab({ games }) {
           sortDir={pvpSort.sortDir}
           onSort={pvpSort.toggle}
           emptyMessage="No PVP kills recorded yet."
+        />
+      </section>
+      <section>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Deaths per Player</h3>
+        <StatsTable
+          columns={playerBreakdownColumns}
+          rows={playerBreakdownRows}
+          sort={playerBreakdownSort.sort}
+          sortKey={playerBreakdownSort.sortKey}
+          sortDir={playerBreakdownSort.sortDir}
+          onSort={playerBreakdownSort.toggle}
+          emptyMessage="No death data yet."
         />
       </section>
     </div>
@@ -352,7 +564,7 @@ export default function Stats() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-6 animate-fade-up">
+      <div className="mb-6 animate-fade-up text-center">
         <h1 className="font-heading text-3xl text-parchment tracking-wide">Stats</h1>
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>

--- a/supabase/migrations/20260416000000_death_tracking.sql
+++ b/supabase/migrations/20260416000000_death_tracking.sql
@@ -1,0 +1,47 @@
+-- ============================================================
+-- Death tracking: death_types seed table + game_player_deaths
+-- ============================================================
+
+-- ── death_types (seed / reference) ──────────────────────────
+create table death_types (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null unique,
+  description text
+);
+
+insert into death_types (name, description) values
+  ('PVP',                    'Killed by another player'),
+  ('Adventure',              'Adventure card enemies'),
+  ('Inner Region',           'Inner region enemies'),
+  ('Crown of Command',       'Killed at the Crown of Command'),
+  ('Spell',                  'Killed by a spell'),
+  ('Suicide',                'Self-inflicted death'),
+  ('Denizen',                'Killed by a denizen'),
+  ('Dungeon',                'Dungeon board enemies'),
+  ('Woodland',               'Woodland board enemies'),
+  ('City',                   'City board enemies'),
+  ('Reaper',                 'Killed by the Reaper'),
+  ('Werewolf',               'Blood Moon werewolf'),
+  ('Harbinger',              'Harbinger events'),
+  ('Dragon',                 'Dragon expansion enemies'),
+  ('Firelands',              'Firelands board enemies'),
+  ('Rat Queen''s Lair',      'Lost Realms - rat side'),
+  ('Wraith Lord''s Domain',  'Lost Realms - spirit side');
+
+-- ── game_player_deaths ──────────────────────────────────────
+create table game_player_deaths (
+  id                    uuid primary key default gen_random_uuid(),
+  game_id               uuid not null references games(id) on delete cascade,
+  player_id             uuid not null references players(id),
+  death_type_id         uuid not null references death_types(id),
+  character_id          uuid not null references characters(id),
+  killed_by_player_id   uuid
+    constraint game_player_deaths_killed_by_fkey
+    references players(id)
+);
+
+create index idx_game_player_deaths_game_player
+  on game_player_deaths (game_id, player_id);
+
+-- ── Drop total_deaths from game_players ─────────────────────
+alter table game_players drop column total_deaths;

--- a/supabase/migrations/20260416100000_add_character_to_deaths.sql
+++ b/supabase/migrations/20260416100000_add_character_to_deaths.sql
@@ -1,0 +1,4 @@
+-- Add character reference to game_player_deaths
+-- Table has no existing rows so NOT NULL is safe without a default
+alter table game_player_deaths
+  add column character_id uuid not null references characters(id);


### PR DESCRIPTION
## Summary
- Add death tracking system with per-character attribution, death types, and PVP kill tracking
- Add new leaderboard columns: win/lose streaks, current streak, survival %, best character (by win rate), and nemesis
- Add avg deaths per game to endings stats tab
- Add Top Death column to leaderboard, character stats, and ending stats
- Track toad times per player and derive winning character
- Center page headers across Leaderboard, Log Game, Highscores, and Stats pages
- Show `X` for irrelevant Talisman row columns in leaderboard

## Test plan
- [ ] Verify leaderboard displays all new columns correctly with real data
- [ ] Verify streak calculations match manual count of game history
- [ ] Verify nemesis shows the correct PVP killer per player
- [ ] Verify best character uses min 2 games threshold and falls back to most wins
- [ ] Verify Talisman row shows X for all columns except Player, Games, Wins, Win %
- [ ] Verify endings tab shows avg deaths per game
- [ ] Verify death tracking works in Log Game flow
- [ ] Verify mobile card layout shows new stats (and hides them for Talisman)
- [ ] Check horizontal scroll on desktop leaderboard table

🤖 Generated with [Claude Code](https://claude.com/claude-code)