### PR TITLE
feat(counters): add Basilisk and Dark Fey encounter scoreboards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import GameHistory from './pages/GameHistory'
 import GameDetail from './pages/GameDetail'
 import Players from './pages/Players'
 import Stats from './pages/Stats'
+import Counters from './pages/Counters'
 
 const queryClient = new QueryClient()
 
@@ -28,6 +29,7 @@ export default function App() {
             <Route path="/games/:id" element={<GameDetail />} />
             <Route path="/players" element={<Players />} />
             <Route path="/stats" element={<Stats />} />
+            <Route path="/counters" element={<Counters />} />
           </Routes>
         </Layout>
       </BrowserRouter>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -7,6 +7,7 @@ const NAV_LINKS = [
   { to: '/leaderboard', label: 'Leaderboard' },
   { to: '/highscores', label: 'Highscores' },
   { to: '/stats', label: 'Stats' },
+  { to: '/counters', label: 'Counters' },
   { to: '/history', label: 'History' },
   { to: '/players', label: 'Players' },
 ]

--- a/src/hooks/useEncounterScores.js
+++ b/src/hooks/useEncounterScores.js
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+
+export function useEncounterScores() {
+  return useQuery({
+    queryKey: ['encounterScores'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('encounter_scores')
+        .select('id, encounter_name, creature_wins, player_wins')
+        .order('encounter_name')
+      if (error) throw error
+      return (data ?? []).map((row) => ({
+        id: row.id,
+        encounterName: row.encounter_name,
+        creatureWins: row.creature_wins,
+        playerWins: row.player_wins,
+      }))
+    },
+  })
+}

--- a/src/hooks/useUpdateEncounterScore.js
+++ b/src/hooks/useUpdateEncounterScore.js
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+
+export function useUpdateEncounterScore() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async ({ encounterName, column, delta }) => {
+      const { data, error } = await supabase.rpc('increment_encounter_score', {
+        p_encounter_name: encounterName,
+        p_column: column,
+        p_delta: delta,
+      })
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['encounterScores'] })
+    },
+  })
+}

--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -1,0 +1,125 @@
+import { useEncounterScores } from '../hooks/useEncounterScores'
+import { useUpdateEncounterScore } from '../hooks/useUpdateEncounterScore'
+
+const ENCOUNTERS = [
+  {
+    name: 'Basilisk',
+    type: 'Strength',
+    description: 'Turns players to stone',
+  },
+  {
+    name: 'Dark Fey',
+    type: 'Craft',
+    description: 'Turns players into a toad on doubles',
+  },
+]
+
+function ScoreButton({ label, onClick, disabled }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="w-9 h-9 rounded-lg border border-gold-dim/20 bg-elevated text-parchment/70 font-heading text-lg transition-colors hover:bg-gold/10 hover:text-gold hover:border-gold-dim/40 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-elevated disabled:hover:text-parchment/70 disabled:hover:border-gold-dim/20"
+    >
+      {label}
+    </button>
+  )
+}
+
+function ScoreSide({ label, value, onIncrement, onDecrement, isPending }) {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <span className="text-xs font-body text-muted uppercase tracking-wider">{label}</span>
+      <span className="font-display text-5xl text-gold tracking-wider tabular-nums">{value}</span>
+      <div className="flex gap-2">
+        <ScoreButton label="-" onClick={onDecrement} disabled={isPending || value <= 0} />
+        <ScoreButton label="+" onClick={onIncrement} disabled={isPending} />
+      </div>
+    </div>
+  )
+}
+
+function EncounterCard({ encounter, score, onUpdate, isPending }) {
+  const creatureWins = score?.creatureWins ?? 0
+  const playerWins = score?.playerWins ?? 0
+
+  return (
+    <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 sm:p-8">
+      <div className="text-center mb-6">
+        <h2 className="font-heading text-xl text-parchment tracking-wide">{encounter.name}</h2>
+        <p className="text-muted text-xs font-body mt-1">
+          {encounter.type} &middot; {encounter.description}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-center gap-8 sm:gap-12">
+        <ScoreSide
+          label={encounter.name}
+          value={creatureWins}
+          onIncrement={() => onUpdate(encounter.name, 'creature_wins', 1)}
+          onDecrement={() => onUpdate(encounter.name, 'creature_wins', -1)}
+          isPending={isPending}
+        />
+
+        <div className="flex flex-col items-center gap-1 select-none">
+          <span className="font-display text-2xl text-gold-dim/40 tracking-widest">vs</span>
+        </div>
+
+        <ScoreSide
+          label="Players"
+          value={playerWins}
+          onIncrement={() => onUpdate(encounter.name, 'player_wins', 1)}
+          onDecrement={() => onUpdate(encounter.name, 'player_wins', -1)}
+          isPending={isPending}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default function Counters() {
+  const { data: scores = [], error, isLoading } = useEncounterScores()
+  const mutation = useUpdateEncounterScore()
+
+  const handleUpdate = (encounterName, column, delta) => {
+    mutation.mutate({ encounterName, column, delta })
+  }
+
+  const scoresByName = new Map(scores.map((s) => [s.encounterName, s]))
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-8 animate-fade-up text-center">
+        <h1 className="font-heading text-3xl text-parchment tracking-wide">Encounter Counters</h1>
+        <div className="ornament-divider mt-3">
+          <span className="text-gold-dim">&#9670;</span>
+        </div>
+        <p className="text-muted text-sm font-body mt-3">
+          Running scoreboards for creature encounters.
+        </p>
+      </div>
+
+      {error && (
+        <p className="text-danger text-sm font-body mb-4">{error.message}</p>
+      )}
+      {isLoading && (
+        <p className="text-muted text-sm font-body italic">Loading...</p>
+      )}
+
+      {!isLoading && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 animate-fade-up delay-1">
+          {ENCOUNTERS.map((encounter) => (
+            <EncounterCard
+              key={encounter.name}
+              encounter={encounter}
+              score={scoresByName.get(encounter.name)}
+              onUpdate={handleUpdate}
+              isPending={mutation.isPending}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/supabase/migrations/20260417000000_encounter_scores.sql
+++ b/supabase/migrations/20260417000000_encounter_scores.sql
@@ -1,0 +1,54 @@
+-- Global encounter score counters (not per-game)
+-- Tracks creature wins vs player wins for specific encounters.
+
+create table encounter_scores (
+  id              uuid primary key default gen_random_uuid(),
+  encounter_name  text not null unique,
+  creature_wins   int not null default 0,
+  player_wins     int not null default 0,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create trigger encounter_scores_set_updated_at
+  before update on encounter_scores
+  for each row execute function set_updated_at();
+
+-- Atomic increment/decrement with upsert and floor at 0
+create or replace function increment_encounter_score(
+  p_encounter_name text,
+  p_column text,
+  p_delta int
+)
+returns encounter_scores
+language plpgsql as $$
+declare
+  result encounter_scores;
+begin
+  insert into encounter_scores (encounter_name, creature_wins, player_wins)
+  values (
+    p_encounter_name,
+    case when p_column = 'creature_wins' then greatest(0, p_delta) else 0 end,
+    case when p_column = 'player_wins'   then greatest(0, p_delta) else 0 end
+  )
+  on conflict (encounter_name) do update set
+    creature_wins = case
+      when p_column = 'creature_wins'
+      then greatest(0, encounter_scores.creature_wins + p_delta)
+      else encounter_scores.creature_wins
+    end,
+    player_wins = case
+      when p_column = 'player_wins'
+      then greatest(0, encounter_scores.player_wins + p_delta)
+      else encounter_scores.player_wins
+    end
+  returning * into result;
+
+  return result;
+end;
+$$;
+
+-- Seed initial rows
+insert into encounter_scores (encounter_name) values
+  ('Basilisk'),
+  ('Dark Fey');


### PR DESCRIPTION
## Summary
- Add dedicated `/counters` page with running scoreboards for Basilisk (Strength) and Dark Fey (Craft) encounters
- Each scoreboard tracks creature wins vs player wins with inline +1/-1 buttons
- Atomic increment/decrement via Postgres RPC function with floor-at-zero clamping
- New `encounter_scores` table with seeded rows for both encounters

Closes #11

## Test plan
- [ ] Navigate to `/counters` and verify both cards render with initial 0/0 scores
- [ ] Click +1 on creature and player sides, confirm scores update and persist on refresh
- [ ] Click -1 to decrement, confirm score floors at 0
- [ ] Verify nav link appears between Stats and History on desktop and mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)