### PR TITLE
feat(stats): character stats by player, crown on counters, remove deaths-per-player

### DIFF
--- a/src/lib/statsAggregations.js
+++ b/src/lib/statsAggregations.js
@@ -124,6 +124,64 @@ export function computeCharacterStats(games, allCharacters) {
   return rows
 }
 
+// ── Characters by Player ─────────────────────────────────────
+// Same shape as computeCharacterStats but keyed per player+character pair.
+export function computeCharacterStatsByPlayer(games, allCharacters) {
+  const stats = new Map()
+  const ensure = (playerName, charName) => {
+    const key = `${playerName}::${charName}`
+    if (!stats.has(key)) {
+      stats.set(key, { playerName, character: charName, games: 0, wins: 0, deaths: 0, deathTypeCounts: new Map() })
+    }
+    return stats.get(key)
+  }
+
+  for (const game of games) {
+    for (const gp of game.players ?? []) {
+      const playerName = gp.player?.name ?? 'Unknown'
+      const chars = gp.characters_played ?? []
+      const deathsByChar = new Map()
+      for (const d of gp.deaths ?? []) {
+        const charName = d.character?.name
+        if (charName) {
+          if (!deathsByChar.has(charName)) deathsByChar.set(charName, [])
+          deathsByChar.get(charName).push(d)
+        }
+      }
+      for (const char of chars) {
+        const row = ensure(playerName, char)
+        row.games += 1
+        const charDeaths = deathsByChar.get(char) ?? []
+        if (charDeaths.length > 0) row.deaths += 1
+        for (const d of charDeaths) {
+          const typeName = d.death_type?.name
+          if (typeName) row.deathTypeCounts.set(typeName, (row.deathTypeCounts.get(typeName) ?? 0) + 1)
+        }
+      }
+      if (gp.is_winner && gp.winning_character) {
+        ensure(playerName, gp.winning_character).wins += 1
+      }
+    }
+  }
+
+  const expansionByName = new Map((allCharacters ?? []).map(c => [c.name, c.expansion]))
+
+  return Array.from(stats.values()).map(row => {
+    let topDeath = 'NA'
+    let maxCount = 0
+    for (const [type, count] of row.deathTypeCounts) {
+      if (count > maxCount) { maxCount = count; topDeath = `${type} (${count})` }
+    }
+    return {
+      ...row,
+      expansion: expansionByName.get(row.character) ?? 'NA',
+      winRate: row.games > 0 ? row.wins / row.games : 0,
+      deathRate: row.games > 0 ? row.deaths / row.games : 0,
+      topDeath,
+    }
+  })
+}
+
 // ── Endings ─────────────────────────────────────────────────
 // For each ending: times triggered, % of games, player win rate,
 // talisman (no-winner) rate, top winning character.

--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -27,9 +27,18 @@ function ScoreButton({ label, onClick, disabled }) {
   )
 }
 
-function ScoreSide({ label, value, onIncrement, onDecrement, isPending }) {
+function Crown() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="w-5 h-5 fill-gold drop-shadow-[0_0_4px_rgba(212,175,55,0.6)]">
+      <path d="M3 18l2-9 5 5 2-9 2 9 5-5 2 9H3z" />
+    </svg>
+  )
+}
+
+function ScoreSide({ label, value, onIncrement, onDecrement, isPending, isWinning }) {
   return (
     <div className="flex flex-col items-center gap-3">
+      <div className="h-5">{isWinning && <Crown />}</div>
       <span className="text-xs font-body text-muted uppercase tracking-wider">{label}</span>
       <span className="font-display text-5xl text-gold tracking-wider tabular-nums">{value}</span>
       <div className="flex gap-2">
@@ -60,6 +69,7 @@ function EncounterCard({ encounter, score, onUpdate, isPending }) {
           onIncrement={() => onUpdate(encounter.name, 'creature_wins', 1)}
           onDecrement={() => onUpdate(encounter.name, 'creature_wins', -1)}
           isPending={isPending}
+          isWinning={creatureWins > playerWins}
         />
 
         <div className="flex flex-col items-center gap-1 select-none">
@@ -72,6 +82,7 @@ function EncounterCard({ encounter, score, onUpdate, isPending }) {
           onIncrement={() => onUpdate(encounter.name, 'player_wins', 1)}
           onDecrement={() => onUpdate(encounter.name, 'player_wins', -1)}
           isPending={isPending}
+          isWinning={playerWins > creatureWins}
         />
       </div>
     </div>

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -5,6 +5,7 @@ import {
   OPTIONAL_EXPANSION_FILTERS,
   filterGamesByOptionalExpansions,
   computeCharacterStats,
+  computeCharacterStatsByPlayer,
   computeEndingStats,
   computeExpansionEventStats,
   computeDeathTypeStats,
@@ -89,21 +90,53 @@ const pct = (v) => `${(v * 100).toFixed(1)}%`
 
 function CharactersTab({ games, allCharacters }) {
   const [expansionFilter, setExpansionFilter] = useState('all')
+  const [selectedPlayer, setSelectedPlayer] = useState('')
   const { sortKey, sortDir, toggle, sort } = useSort('games', 'desc')
+  const playerSort = useSort('games', 'desc')
 
   const rows = useMemo(
     () => computeCharacterStats(games, allCharacters),
     [games, allCharacters],
   )
+  const byPlayerRows = useMemo(
+    () => computeCharacterStatsByPlayer(games, allCharacters),
+    [games, allCharacters],
+  )
+
   const expansions = useMemo(() => {
     const set = new Set(rows.map(r => r.expansion).filter(Boolean))
     return Array.from(set).sort()
   }, [rows])
+
+  const playerNames = useMemo(() => {
+    const set = new Set(byPlayerRows.map(r => r.playerName))
+    return Array.from(set).sort()
+  }, [byPlayerRows])
+
   const filtered = expansionFilter === 'all'
     ? rows
     : rows.filter(r => r.expansion === expansionFilter)
 
-  const columns = [
+  const filteredByPlayer = useMemo(() => {
+    if (!selectedPlayer) {
+      return [...byPlayerRows].sort((a, b) => b.games - a.games).slice(0, 5)
+    }
+    return byPlayerRows.filter(r => r.playerName === selectedPlayer)
+  }, [byPlayerRows, selectedPlayer])
+
+  const globalColumns = [
+    { key: 'character', label: 'Character', align: 'left' },
+    { key: 'expansion', label: 'Expansion', align: 'left' },
+    { key: 'games', label: 'Games', align: 'center' },
+    { key: 'wins', label: 'Wins', align: 'center' },
+    { key: 'winRate', label: 'Win %', align: 'center', format: pct, accent: true },
+    { key: 'deaths', label: 'Deaths', align: 'center' },
+    { key: 'deathRate', label: 'Death %', align: 'center', format: pct },
+    { key: 'topDeath', label: 'Top Death', align: 'left', sortable: false },
+  ]
+
+  const playerColumns = [
+    ...(!selectedPlayer ? [{ key: 'playerName', label: 'Player', align: 'left' }] : []),
     { key: 'character', label: 'Character', align: 'left' },
     { key: 'expansion', label: 'Expansion', align: 'left' },
     { key: 'games', label: 'Games', align: 'center' },
@@ -115,27 +148,52 @@ function CharactersTab({ games, allCharacters }) {
   ]
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-xs font-body text-muted uppercase tracking-wider">Expansion</span>
-        <select
-          className="input-field text-sm py-1.5 w-auto"
-          value={expansionFilter}
-          onChange={e => setExpansionFilter(e.target.value)}
-        >
-          <option value="all">All</option>
-          {expansions.map(e => <option key={e} value={e}>{e}</option>)}
-        </select>
-      </div>
-      <StatsTable
-        columns={columns}
-        rows={filtered}
-        sort={sort}
-        sortKey={sortKey}
-        sortDir={sortDir}
-        onSort={toggle}
-        emptyMessage="No character data yet."
-      />
+    <div className="space-y-8">
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-body text-muted uppercase tracking-wider">Expansion</span>
+          <select
+            className="input-field text-sm py-1.5 w-auto"
+            value={expansionFilter}
+            onChange={e => setExpansionFilter(e.target.value)}
+          >
+            <option value="all">All</option>
+            {expansions.map(e => <option key={e} value={e}>{e}</option>)}
+          </select>
+        </div>
+        <StatsTable
+          columns={globalColumns}
+          rows={filtered}
+          sort={sort}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={toggle}
+          emptyMessage="No character data yet."
+        />
+      </section>
+      <section className="space-y-4">
+        <h3 className="font-heading text-lg text-parchment tracking-wide">Characters by Player</h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-body text-muted uppercase tracking-wider">Player</span>
+          <select
+            className="input-field text-sm py-1.5 w-auto"
+            value={selectedPlayer}
+            onChange={e => setSelectedPlayer(e.target.value)}
+          >
+            <option value="">Top 5</option>
+            {playerNames.map(name => <option key={name} value={name}>{name}</option>)}
+          </select>
+        </div>
+        <StatsTable
+          columns={playerColumns}
+          rows={filteredByPlayer}
+          sort={playerSort.sort}
+          sortKey={playerSort.sortKey}
+          sortDir={playerSort.sortDir}
+          onSort={playerSort.toggle}
+          emptyMessage="No character data for this player."
+        />
+      </section>
     </div>
   )
 }
@@ -379,7 +437,6 @@ function ExpansionsTab({ games }) {
 
 function DeathsTab({ games }) {
   const deathTypeSort = useSort('count', 'desc')
-  const playerBreakdownSort = useSort('count', 'desc')
   const playerFilterSort = useSort('count', 'desc')
   const charFilterSort = useSort('count', 'desc')
   const pvpSort = useSort('count', 'desc')
@@ -432,12 +489,6 @@ function DeathsTab({ games }) {
     { key: 'deathType', label: 'Death Type', align: 'left' },
     { key: 'count', label: 'Count', align: 'center', accent: true },
     { key: 'pctOfAllDeaths', label: '% of Deaths', align: 'center', format: pct },
-  ]
-
-  const playerBreakdownColumns = [
-    { key: 'playerName', label: 'Player', align: 'left' },
-    { key: 'deathType', label: 'Death Type', align: 'left' },
-    { key: 'count', label: 'Count', align: 'center', accent: true },
   ]
 
   const pvpColumns = [
@@ -533,18 +584,6 @@ function DeathsTab({ games }) {
           sortDir={pvpSort.sortDir}
           onSort={pvpSort.toggle}
           emptyMessage="No PVP kills recorded yet."
-        />
-      </section>
-      <section>
-        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Deaths per Player</h3>
-        <StatsTable
-          columns={playerBreakdownColumns}
-          rows={playerBreakdownRows}
-          sort={playerBreakdownSort.sort}
-          sortKey={playerBreakdownSort.sortKey}
-          sortDir={playerBreakdownSort.sortDir}
-          onSort={playerBreakdownSort.toggle}
-          emptyMessage="No death data yet."
         />
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Added **Characters by Player** section in Stats → Characters tab: player filter dropdown with Top 5 default, same stat columns as the global table
- Added **winning crown indicator** on Counters page above the leading side (hidden on ties)
- Removed **Deaths per Player** table from Stats → Deaths tab

## Test plan
- [ ] Stats → Characters tab: verify "Characters by Player" section appears below the global table, Top 5 shows top combos, player filter narrows to that player's chars
- [ ] Counters page: verify crown appears above the side with the higher score, disappears on tie, switches sides correctly
- [ ] Stats → Deaths tab: confirm "Deaths per Player" section is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)