### PR TITLE
fix(nav): mobile menu overflow + endings reseed

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -82,7 +82,7 @@ export default function Layout({ children }) {
         {/* Mobile menu */}
         <div
           className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
-            mobileOpen ? 'max-h-80 opacity-100' : 'max-h-0 opacity-0'
+            mobileOpen ? 'max-h-[32rem] opacity-100' : 'max-h-0 opacity-0'
           }`}
         >
           <div className="px-4 pb-4 pt-1 space-y-1 bg-deep/95 border-t border-gold-dim/10">

--- a/supabase/migrations/20260419020000_reseed_endings.sql
+++ b/supabase/migrations/20260419020000_reseed_endings.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- Reseed endings with full per-expansion list + hidden flag.
+-- Source: GitHub issue #5.
+-- The one existing game is repointed to "Spreading Flames".
+-- ============================================================
+
+-- 1. Add hidden_type column (nullable for now so we can tag new rows)
+alter table endings add column hidden_type text;
+
+-- 2. Insert new endings
+insert into endings (name, expansion, hidden_type) values
+  -- Base game
+  ('Crown of Command',      'base',         'not_hidden'),
+
+  -- The Nether Realm
+  ('The Hunt',              'nether',       'not_hidden'),
+  ('The Gauntlet',          'nether',       'not_hidden'),
+  ('Pandora''s Box',        'nether',       'both'),
+
+  -- The Dragon
+  ('Dragon King',           'dragon',       'both'),
+  ('Dragon Slayers',        'dragon',       'not_hidden'),
+  ('Domain of Dragons',     'dragon',       'not_hidden'),
+
+  -- The Woodland
+  ('War of Seasons',        'woodland',     'both'),
+  ('Judged by Fate',        'woodland',     'hidden'),
+  ('Wanderlust',            'woodland',     'not_hidden'),
+
+  -- The City
+  ('Merchants'' Guild',     'city',         'not_hidden'),
+  ('Assassins'' Guild',     'city',         'not_hidden'),
+  ('Thieves'' Guild',       'city',         'both'),
+
+  -- The Harbinger
+  ('End of Days',           'harbinger',    'not_hidden'),
+  ('Armageddon Crown',      'harbinger',    'both'),
+
+  -- The Firelands
+  ('A Hero Rises',          'firelands',    'not_hidden'),
+  ('Crown of Flame',        'firelands',    'hidden'),
+  ('Spreading Flames',      'firelands',    'hidden'),
+
+  -- The Cataclysm
+  ('Lands of Wonder',       'cataclysm',    'not_hidden'),
+  ('The One Talisman',      'cataclysm',    'not_hidden'),
+  ('Cult of the Damned',    'cataclysm',    'hidden'),
+  ('The Eternal Crown',     'cataclysm',    'both'),
+
+  -- The Sacred Pool
+  ('Sacred Pool',           'sacred_pool',  'not_hidden'),
+  ('Judgement Day',         'sacred_pool',  'both'),
+  ('Demon Lord',            'sacred_pool',  'both'),
+
+  -- The Blood Moon
+  ('Horrible Black Void',   'blood_moon',   'hidden'),
+  ('Blood Moon Werewolf',   'blood_moon',   'hidden'),
+  ('Lightbearers',          'blood_moon',   'not_hidden');
+
+-- 3. Repoint any existing games (the one logged game in prod) to "Spreading Flames".
+--    Old endings are identified by hidden_type being null (nothing above left it null).
+update games
+set ending_id = (
+  select id from endings
+  where name = 'Spreading Flames' and expansion = 'firelands'
+  limit 1
+)
+where ending_id in (select id from endings where hidden_type is null);
+
+-- 4. Remove the old seeded endings.
+delete from endings where hidden_type is null;
+
+-- 5. Lock down the column.
+alter table endings alter column hidden_type set not null;
+alter table endings
+  add constraint endings_hidden_type_check
+  check (hidden_type in ('hidden', 'not_hidden', 'both'));

--- a/supabase/migrations/20260419030000_rename_crown_death_type.sql
+++ b/supabase/migrations/20260419030000_rename_crown_death_type.sql
@@ -1,0 +1,5 @@
+-- Rename the "Crown of Command" death type to "Ending" (covers all ending deaths, not only CoC).
+update death_types
+set name = 'Ending',
+    description = 'Killed at the game''s ending'
+where name = 'Crown of Command';


### PR DESCRIPTION
## Summary
- Raise mobile nav menu `max-h-80` → `max-h-[32rem]` so all 9 tabs are visible on mobile (previously clipped after "History").
- Reseed `endings` with the full per-expansion list from #5, add `hidden_type` column (`hidden` / `not_hidden` / `both`). Existing game repointed to "Spreading Flames".
- Rename "Crown of Command" death type to "Ending".

## Test plan
- [ ] Open mobile viewport, confirm all 9 nav links are reachable
- [ ] Log Game → Ending dropdown shows new endings grouped by expansion
- [ ] Existing game in History still opens (points to "Spreading Flames")
- [ ] Death type picker shows "Ending" instead of "Crown of Command"

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)