### PR TITLE
feat: groups foundation — auth, schema, create-group UX (#63, #64, #65)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ProtectedRoute from './components/ProtectedRoute'
 import Layout from './components/Layout'
 import Login from './pages/Login'
 import AuthCallback from './pages/AuthCallback'
+import Setup from './pages/Setup'
 import Home from './pages/Home'
 import LogGame from './pages/LogGame'
 import EditGame from './pages/EditGame'
@@ -41,6 +42,7 @@ export default function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route element={<ProtectedLayout />}>
+              <Route path="/setup" element={<Setup />} />
               <Route path="/" element={<Home />} />
               <Route path="/log" element={<LogGame />} />
               <Route path="/games/:id/edit" element={<EditGame />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,10 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Outlet } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider } from './context/AuthProvider'
+import ProtectedRoute from './components/ProtectedRoute'
 import Layout from './components/Layout'
+import Login from './pages/Login'
+import AuthCallback from './pages/AuthCallback'
 import Home from './pages/Home'
 import LogGame from './pages/LogGame'
 import EditGame from './pages/EditGame'
@@ -18,29 +22,43 @@ import Tierlist from './pages/Tierlist'
 
 const queryClient = new QueryClient()
 
+function ProtectedLayout() {
+  return (
+    <ProtectedRoute>
+      <Layout>
+        <Outlet />
+      </Layout>
+    </ProtectedRoute>
+  )
+}
+
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <Layout>
+      <AuthProvider>
+        <BrowserRouter>
           <Routes>
-            <Route path="/" element={<Home />} />
-            <Route path="/log" element={<LogGame />} />
-            <Route path="/games/:id/edit" element={<EditGame />} />
-            <Route path="/leaderboard" element={<Leaderboard />} />
-            <Route path="/highscores" element={<HighscoresBoard />} />
-            <Route path="/history" element={<GameHistory />} />
-            <Route path="/games/:id" element={<GameDetail />} />
-            <Route path="/players" element={<Players />} />
-            <Route path="/players/:id/tierlist" element={<Tierlist />} />
-            <Route path="/stats" element={<Stats />} />
-            <Route path="/counters" element={<Counters />} />
-            <Route path="/house-rules" element={<HouseRules />} />
-            <Route path="/house-rules/rules" element={<HouseRulesContent />} />
-            <Route path="/house-rules/rulebooks" element={<Rulebooks />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
+            <Route element={<ProtectedLayout />}>
+              <Route path="/" element={<Home />} />
+              <Route path="/log" element={<LogGame />} />
+              <Route path="/games/:id/edit" element={<EditGame />} />
+              <Route path="/leaderboard" element={<Leaderboard />} />
+              <Route path="/highscores" element={<HighscoresBoard />} />
+              <Route path="/history" element={<GameHistory />} />
+              <Route path="/games/:id" element={<GameDetail />} />
+              <Route path="/players" element={<Players />} />
+              <Route path="/players/:id/tierlist" element={<Tierlist />} />
+              <Route path="/stats" element={<Stats />} />
+              <Route path="/counters" element={<Counters />} />
+              <Route path="/house-rules" element={<HouseRules />} />
+              <Route path="/house-rules/rules" element={<HouseRulesContent />} />
+              <Route path="/house-rules/rulebooks" element={<Rulebooks />} />
+            </Route>
           </Routes>
-        </Layout>
-      </BrowserRouter>
+        </BrowserRouter>
+      </AuthProvider>
     </QueryClientProvider>
   )
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Layout from './components/Layout'
 import Login from './pages/Login'
 import AuthCallback from './pages/AuthCallback'
 import Setup from './pages/Setup'
+import CreateGroup from './pages/CreateGroup'
 import Home from './pages/Home'
 import LogGame from './pages/LogGame'
 import EditGame from './pages/EditGame'
@@ -43,6 +44,7 @@ export default function App() {
             <Route path="/auth/callback" element={<AuthCallback />} />
             <Route element={<ProtectedLayout />}>
               <Route path="/setup" element={<Setup />} />
+              <Route path="/groups/new" element={<CreateGroup />} />
               <Route path="/" element={<Home />} />
               <Route path="/log" element={<LogGame />} />
               <Route path="/games/:id/edit" element={<EditGame />} />

--- a/src/components/GroupSwitcher.jsx
+++ b/src/components/GroupSwitcher.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+
+export default function GroupSwitcher({ onNavigate }) {
+  const { activeGroup, groups, setActiveGroup } = useActiveGroup()
+  const [open, setOpen] = useState(false)
+  const navigate = useNavigate()
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const label = activeGroup?.name ?? 'No group'
+
+  const choose = (id) => {
+    setActiveGroup(id)
+    setOpen(false)
+    onNavigate?.()
+  }
+
+  const goCreate = () => {
+    setOpen(false)
+    onNavigate?.()
+    navigate('/groups/new')
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="px-3 py-1.5 text-sm font-heading text-parchment/80 border border-gold-dim/40 rounded hover:text-gold hover:border-gold-dim transition-colors"
+      >
+        {label} <span aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-56 bg-deep border border-gold-dim/40 rounded shadow-lg z-50 overflow-hidden">
+          {groups.length === 0 && (
+            <div className="px-3 py-2 text-xs text-parchment/50 font-body italic">
+              You're not in any groups yet.
+            </div>
+          )}
+          {groups.map((g) => (
+            <button
+              key={g.id}
+              type="button"
+              onClick={() => choose(g.id)}
+              className={`w-full text-left px-3 py-2 text-sm font-heading transition-colors ${
+                g.id === activeGroup?.id
+                  ? 'text-gold bg-gold/10'
+                  : 'text-parchment hover:bg-gold/5'
+              }`}
+            >
+              {g.name}
+            </button>
+          ))}
+          <button
+            type="button"
+            disabled
+            title="Global view — coming soon"
+            className="w-full text-left px-3 py-2 text-sm font-heading text-parchment/40 cursor-not-allowed"
+          >
+            Global (disabled)
+          </button>
+          <div className="border-t border-gold-dim/20" />
+          <button
+            type="button"
+            onClick={goCreate}
+            className="w-full text-left px-3 py-2 text-sm font-heading text-gold hover:bg-gold/10 transition-colors"
+          >
+            + Create group
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
 
 const NAV_LINKS = [
   { to: '/', label: 'Home' },
@@ -34,6 +35,12 @@ function HamburgerIcon({ open }) {
 
 export default function Layout({ children }) {
   const [mobileOpen, setMobileOpen] = useState(false)
+  const { user, signOut } = useAuth()
+
+  const handleSignOut = async () => {
+    setMobileOpen(false)
+    await signOut()
+  }
 
   const linkClasses = ({ isActive }) =>
     `font-heading text-sm tracking-wide transition-colors duration-200 ${
@@ -66,6 +73,14 @@ export default function Layout({ children }) {
                   {link.label}
                 </NavLink>
               ))}
+              {user && (
+                <button
+                  onClick={handleSignOut}
+                  className="font-heading text-sm tracking-wide text-parchment/70 hover:text-gold-light transition-colors"
+                >
+                  Logout
+                </button>
+              )}
             </div>
 
             {/* Mobile hamburger */}
@@ -103,6 +118,14 @@ export default function Layout({ children }) {
                 {link.label}
               </NavLink>
             ))}
+            {user && (
+              <button
+                onClick={handleSignOut}
+                className="block w-full text-left py-2.5 px-3 rounded-lg font-heading text-sm tracking-wide text-parchment/70 hover:text-gold-light hover:bg-gold/5 transition-colors"
+              >
+                Logout
+              </button>
+            )}
           </div>
         </div>
       </nav>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import GroupSwitcher from './GroupSwitcher'
 
 const NAV_LINKS = [
   { to: '/', label: 'Home' },
@@ -73,6 +74,7 @@ export default function Layout({ children }) {
                   {link.label}
                 </NavLink>
               ))}
+              {user && <GroupSwitcher />}
               {user && (
                 <button
                   onClick={handleSignOut}
@@ -118,6 +120,11 @@ export default function Layout({ children }) {
                 {link.label}
               </NavLink>
             ))}
+            {user && (
+              <div className="pt-2 pb-1 px-1">
+                <GroupSwitcher onNavigate={() => setMobileOpen(false)} />
+              </div>
+            )}
             {user && (
               <button
                 onClick={handleSignOut}

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,0 +1,21 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+
+export default function ProtectedRoute({ children }) {
+  const { user, loading } = useAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-parchment bg-deep">
+        Loading…
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  return children
+}

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,11 +1,13 @@
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
+import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
 
 export default function ProtectedRoute({ children }) {
   const { user, loading } = useAuth()
   const location = useLocation()
+  const { data: player, isLoading: playerLoading } = useCurrentPlayer()
 
-  if (loading) {
+  if (loading || (user && playerLoading)) {
     return (
       <div className="min-h-screen flex items-center justify-center text-parchment bg-deep">
         Loading…
@@ -15,6 +17,14 @@ export default function ProtectedRoute({ children }) {
 
   if (!user) {
     return <Navigate to="/login" state={{ from: location }} replace />
+  }
+
+  if (!player && location.pathname !== '/setup') {
+    return <Navigate to="/setup" replace />
+  }
+
+  if (player && location.pathname === '/setup') {
+    return <Navigate to="/" replace />
   }
 
   return children

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+export const AuthContext = createContext({
+  user: null,
+  loading: true,
+  signOut: async () => {},
+})

--- a/src/context/AuthProvider.jsx
+++ b/src/context/AuthProvider.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../supabaseClient'
+import { AuthContext } from './AuthContext'
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setUser(data.session?.user ?? null)
+      setLoading(false)
+    })
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+
+    return () => sub.subscription.unsubscribe()
+  }, [])
+
+  const signOut = async () => {
+    await supabase.auth.signOut()
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}

--- a/src/hooks/useActiveGroup.js
+++ b/src/hooks/useActiveGroup.js
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { useGroups } from './useGroups'
+
+const STORAGE_KEY = 'activeGroupId'
+
+function readStored() {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(STORAGE_KEY)
+}
+
+export function useActiveGroup() {
+  const { data: groups = [], isLoading } = useGroups()
+  const [storedId, setStoredId] = useState(readStored)
+
+  // If groups have loaded and the stored id isn't one of them, treat as null.
+  // The stale value can stay in localStorage — it gets overwritten on next pick,
+  // and this derivation filters it out on read.
+  const isStale = !isLoading && storedId && !groups.find((g) => g.id === storedId)
+  const activeGroupId = isStale ? null : storedId
+  const activeGroup = groups.find((g) => g.id === activeGroupId) ?? null
+
+  const setActiveGroup = (id) => {
+    setStoredId(id)
+    if (id) localStorage.setItem(STORAGE_KEY, id)
+    else localStorage.removeItem(STORAGE_KEY)
+  }
+
+  return { activeGroupId, activeGroup, groups, setActiveGroup, isLoading }
+}

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,0 +1,6 @@
+import { useContext } from 'react'
+import { AuthContext } from '../context/AuthContext'
+
+export function useAuth() {
+  return useContext(AuthContext)
+}

--- a/src/hooks/useCurrentPlayer.js
+++ b/src/hooks/useCurrentPlayer.js
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from './useAuth'
+
+export function useCurrentPlayer() {
+  const { user } = useAuth()
+
+  return useQuery({
+    queryKey: ['currentPlayer', user?.id],
+    enabled: !!user,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('players')
+        .select('*')
+        .eq('user_id', user.id)
+        .maybeSingle()
+      if (error) throw error
+      return data
+    },
+  })
+}

--- a/src/hooks/useGroups.js
+++ b/src/hooks/useGroups.js
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from './useAuth'
+
+export function useGroups() {
+  const { user } = useAuth()
+
+  return useQuery({
+    queryKey: ['groups', user?.id],
+    enabled: !!user,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('group_members')
+        .select('groups(id, name, admin_user_id, invite_code)')
+        .eq('user_id', user.id)
+      if (error) throw error
+      return data.map((row) => row.groups).filter(Boolean)
+    },
+  })
+}

--- a/src/hooks/usePlayers.js
+++ b/src/hooks/usePlayers.js
@@ -1,23 +1,45 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { useActiveGroup } from './useActiveGroup'
+import { useCurrentPlayer } from './useCurrentPlayer'
+
+const PLAYER_COLUMNS =
+  'id, name, created_at, icon_key, icon_character_id, favorite_character_id, user_id'
+
+function normalize(p) {
+  return {
+    id: p.id,
+    name: p.name,
+    createdAt: p.created_at,
+    iconKey: p.icon_key,
+    iconCharacterId: p.icon_character_id,
+    favoriteCharacterId: p.favorite_character_id,
+    userId: p.user_id,
+  }
+}
 
 export function usePlayers() {
+  const { activeGroupId, isLoading: groupsLoading } = useActiveGroup()
+  const { data: currentPlayer, isLoading: currentLoading } = useCurrentPlayer()
+
   return useQuery({
-    queryKey: ['players'],
+    queryKey: ['players', activeGroupId ?? 'self', currentPlayer?.id ?? null],
+    enabled: !groupsLoading && !currentLoading,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('players')
-        .select('id, name, created_at, icon_key, icon_character_id, favorite_character_id')
-        .order('name', { ascending: true })
-      if (error) throw error
-      return data.map((p) => ({
-        id: p.id,
-        name: p.name,
-        createdAt: p.created_at,
-        iconKey: p.icon_key,
-        iconCharacterId: p.icon_character_id,
-        favoriteCharacterId: p.favorite_character_id,
-      }))
+      if (activeGroupId) {
+        const { data, error } = await supabase
+          .from('group_members')
+          .select(`players(${PLAYER_COLUMNS})`)
+          .eq('group_id', activeGroupId)
+        if (error) throw error
+        return data
+          .map((row) => row.players)
+          .filter(Boolean)
+          .map(normalize)
+          .sort((a, b) => a.name.localeCompare(b.name))
+      }
+      if (!currentPlayer) return []
+      return [normalize(currentPlayer)]
     },
   })
 }

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '../supabaseClient'
+
+export default function AuthCallback() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) navigate('/', { replace: true })
+      else navigate('/login', { replace: true })
+    })
+  }, [navigate])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center text-parchment bg-deep">
+      Signing you in…
+    </div>
+  )
+}

--- a/src/pages/CreateGroup.jsx
+++ b/src/pages/CreateGroup.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from '../hooks/useAuth'
+import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+
+function generateInviteCode() {
+  const bytes = crypto.getRandomValues(new Uint8Array(8))
+  return Array.from(bytes, (b) => b.toString(36).padStart(2, '0')).join('').slice(0, 12)
+}
+
+export default function CreateGroup() {
+  const { user } = useAuth()
+  const { data: player } = useCurrentPlayer()
+  const { setActiveGroup } = useActiveGroup()
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  const onSubmit = async (e) => {
+    e.preventDefault()
+    if (!player) {
+      setError('Finish your profile setup first.')
+      return
+    }
+    setSubmitting(true)
+    setError(null)
+
+    const inviteCode = generateInviteCode()
+    const { data: group, error: groupErr } = await supabase
+      .from('groups')
+      .insert({ name: name.trim(), admin_user_id: user.id, invite_code: inviteCode })
+      .select()
+      .single()
+    if (groupErr) {
+      setError(groupErr.message)
+      setSubmitting(false)
+      return
+    }
+
+    const { error: memberErr } = await supabase
+      .from('group_members')
+      .insert({ group_id: group.id, user_id: user.id, player_id: player.id })
+    if (memberErr) {
+      setError(memberErr.message)
+      setSubmitting(false)
+      return
+    }
+
+    await qc.invalidateQueries({ queryKey: ['groups', user.id] })
+    setActiveGroup(group.id)
+    navigate('/', { replace: true })
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-16 px-4 space-y-6">
+      <div className="space-y-2">
+        <h1 className="font-display text-3xl text-gold tracking-wider">Create a group</h1>
+        <p className="text-parchment/80 font-body">
+          Groups scope games, counters, and leaderboards to your fellowship. You'll be the admin.
+        </p>
+      </div>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <label className="block">
+          <span className="block text-sm text-parchment/80 mb-1 font-heading">Group name</span>
+          <input
+            required
+            minLength={1}
+            maxLength={60}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={submitting || !name.trim()}
+          className="w-full px-4 py-2 bg-gold text-deep font-heading tracking-wide rounded disabled:opacity-50 hover:bg-gold-light transition-colors"
+        >
+          {submitting ? 'Creating…' : 'Create group'}
+        </button>
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+      </form>
+    </div>
+  )
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { supabase } from '../supabaseClient'
+
+export default function Login() {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState('idle')
+  const [error, setError] = useState(null)
+
+  const onSubmit = async (e) => {
+    e.preventDefault()
+    setStatus('sending')
+    setError(null)
+    const redirectUrl = `${window.location.origin}/auth/callback`
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: redirectUrl },
+    })
+    if (error) {
+      setError(error.message)
+      setStatus('idle')
+    } else {
+      setStatus('sent')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-deep">
+      <div className="max-w-md w-full space-y-8">
+        <div className="text-center space-y-2">
+          <img src="/icons/talisman-logo.png" alt="" className="w-16 h-16 mx-auto" />
+          <h1 className="font-display text-3xl text-gold tracking-wider">Talisman Tracker</h1>
+        </div>
+        {status === 'sent' ? (
+          <div className="text-center space-y-2">
+            <p className="text-parchment font-heading">Check your email.</p>
+            <p className="text-parchment/70 text-sm">
+              We sent a magic link to <span className="text-gold">{email}</span>. Click it to sign in.
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={onSubmit} className="space-y-4">
+            <label className="block">
+              <span className="block text-sm text-parchment/80 mb-1 font-heading">Email</span>
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={status === 'sending'}
+              className="w-full px-4 py-2 bg-gold text-deep font-heading tracking-wide rounded disabled:opacity-50 hover:bg-gold-light transition-colors"
+            >
+              {status === 'sending' ? 'Sending…' : 'Send magic link'}
+            </button>
+            {error && <p className="text-red-400 text-sm">{error}</p>}
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Players.jsx
+++ b/src/pages/Players.jsx
@@ -5,6 +5,7 @@ import { useLeaderboardStats } from '../hooks/useLeaderboardStats'
 import { useAddPlayer } from '../hooks/useAddPlayer'
 import { useUpdatePlayer } from '../hooks/useUpdatePlayer'
 import { useCharacters } from '../hooks/useCharacters'
+import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
 import { IconPicker } from '../components/IconPicker'
 import { AVAILABLE_ICONS } from '../data/availableIcons'
 
@@ -18,12 +19,15 @@ function PlayerAvatar({ iconKey, name, onClick, size = 'lg' }) {
     ? 'avatar-heraldic'
     : 'border border-gold-dim/20 hover:border-gold/50 transition-colors'
 
+  const interactive = typeof onClick === 'function'
+
   if (!iconKey) {
     return (
       <button
         onClick={onClick}
-        title="Set profile icon"
-        className={`${dim} rounded-xl bg-elevated flex items-center justify-center ${text} font-heading text-gold-dim ${frame}`}
+        disabled={!interactive}
+        title={interactive ? 'Set profile icon' : undefined}
+        className={`${dim} rounded-xl bg-elevated flex items-center justify-center ${text} font-heading text-gold-dim ${frame} ${interactive ? '' : 'cursor-default'}`}
       >
         {name.charAt(0).toUpperCase()}
       </button>
@@ -33,8 +37,9 @@ function PlayerAvatar({ iconKey, name, onClick, size = 'lg' }) {
   return (
     <button
       onClick={onClick}
-      title="Change profile icon"
-      className={`${dim} rounded-xl overflow-hidden ${frame}`}
+      disabled={!interactive}
+      title={interactive ? 'Change profile icon' : undefined}
+      className={`${dim} rounded-xl overflow-hidden ${frame} ${interactive ? '' : 'cursor-default'}`}
     >
       <img
         src={iconSrc(iconKey)}
@@ -68,8 +73,11 @@ export default function Players() {
   const playersQuery = usePlayers()
   const statsQuery = useLeaderboardStats()
   const { data: allCharacters = [] } = useCharacters()
+  const { data: currentPlayer } = useCurrentPlayer()
   const addPlayer = useAddPlayer()
   const updatePlayer = useUpdatePlayer()
+
+  const canEdit = (player) => !!currentPlayer && player.id === currentPlayer.id
 
   const expansionOrder = [
     'Base Game', 'The Reaper', 'The Frostmarch', 'The Dragon', 'The Woodland',
@@ -168,12 +176,18 @@ export default function Players() {
             >
               <div className="flex items-center justify-between gap-3 mb-3 pb-3 border-b border-gold-dim/10">
                 <div>
-                  <button
-                    onClick={() => openEditModal(player)}
-                    className="font-heading text-lg text-parchment tracking-wide hover:text-gold transition-colors text-left"
-                  >
-                    {player.name}
-                  </button>
+                  {canEdit(player) ? (
+                    <button
+                      onClick={() => openEditModal(player)}
+                      className="font-heading text-lg text-parchment tracking-wide hover:text-gold transition-colors text-left"
+                    >
+                      {player.name}
+                    </button>
+                  ) : (
+                    <span className="font-heading text-lg text-parchment tracking-wide">
+                      {player.name}
+                    </span>
+                  )}
                   <div className="mt-0.5">
                     <span className="text-muted text-xs font-body">Favourite Character</span>
                     <p className="text-sm font-body text-parchment/80">
@@ -184,7 +198,7 @@ export default function Players() {
                 <PlayerAvatar
                   iconKey={player.iconKey}
                   name={player.name}
-                  onClick={() => openEditModal(player)}
+                  onClick={canEdit(player) ? () => openEditModal(player) : undefined}
                 />
               </div>
               <div className="grid grid-cols-2 gap-y-2 text-sm font-body">

--- a/src/pages/Setup.jsx
+++ b/src/pages/Setup.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from '../hooks/useAuth'
+
+export default function Setup() {
+  const { user } = useAuth()
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+  const [name, setName] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  const onSubmit = async (e) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    const { error } = await supabase
+      .from('players')
+      .insert({ name: name.trim(), user_id: user.id })
+    if (error) {
+      setError(error.message)
+      setSubmitting(false)
+      return
+    }
+    await qc.invalidateQueries({ queryKey: ['currentPlayer', user.id] })
+    navigate('/', { replace: true })
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-deep">
+      <div className="max-w-md w-full space-y-6">
+        <div className="space-y-2">
+          <h1 className="font-display text-3xl text-gold tracking-wider">Set up your profile</h1>
+          <p className="text-parchment/80 font-body">
+            Pick a display name to appear on leaderboards and game logs. You can change it later.
+          </p>
+        </div>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <label className="block">
+            <span className="block text-sm text-parchment/80 mb-1 font-heading">Display name</span>
+            <input
+              required
+              minLength={1}
+              maxLength={40}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={submitting || !name.trim()}
+            className="w-full px-4 py-2 bg-gold text-deep font-heading tracking-wide rounded disabled:opacity-50 hover:bg-gold-light transition-colors"
+          >
+            {submitting ? 'Saving…' : 'Continue'}
+          </button>
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/supabase/migrations/20260420000000_auth_and_players_user_id.sql
+++ b/supabase/migrations/20260420000000_auth_and_players_user_id.sql
@@ -1,0 +1,64 @@
+-- Link players to auth.users (one player per user).
+alter table players
+  add column user_id uuid references auth.users(id) on delete set null;
+
+create unique index players_user_id_unique on players(user_id) where user_id is not null;
+
+-- Drop name uniqueness so two users can pick the same display name.
+alter table players drop constraint if exists players_name_key;
+
+-- Enable RLS on every existing table with permissive policies.
+-- Later issues (#72/#73) will tighten these per-table once active-group scoping lands.
+
+do $$
+declare
+  t text;
+  tables text[] := array[
+    'players',
+    'characters',
+    'endings',
+    'games',
+    'game_players',
+    'game_highscores',
+    'game_expansion_events',
+    'death_types',
+    'game_player_deaths',
+    'encounter_scores',
+    'icons',
+    'tierlists'
+  ];
+begin
+  foreach t in array tables loop
+    execute format('alter table %I enable row level security', t);
+    execute format(
+      'create policy %I on %I for select using (true)',
+      t || '_select_all', t
+    );
+    execute format(
+      'create policy %I on %I for insert with check (true)',
+      t || '_insert_all', t
+    );
+    execute format(
+      'create policy %I on %I for update using (true) with check (true)',
+      t || '_update_all', t
+    );
+    execute format(
+      'create policy %I on %I for delete using (true)',
+      t || '_delete_all', t
+    );
+  end loop;
+end $$;
+
+-- Tighten players write policies: only the matching auth user may update or delete their own row.
+drop policy if exists players_update_all on players;
+drop policy if exists players_delete_all on players;
+
+create policy players_update_self on players
+  for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+create policy players_delete_self on players
+  for delete using (user_id = auth.uid());
+
+-- Inserts stay permissive; /setup sets user_id = auth.uid() on insert.
+-- Tighter insert policy (require user_id = auth.uid()) can land in a later issue
+-- once legacy player rows are reassigned.

--- a/supabase/migrations/20260420000100_groups_schema.sql
+++ b/supabase/migrations/20260420000100_groups_schema.sql
@@ -1,0 +1,148 @@
+-- Groups
+create table groups (
+  id              uuid primary key default gen_random_uuid(),
+  name            text not null,
+  admin_user_id   uuid not null references auth.users(id) on delete cascade,
+  invite_code     text not null unique,
+  created_at      timestamptz not null default now()
+);
+
+create index groups_admin_user_id_idx on groups(admin_user_id);
+
+-- Membership: one user can be in multiple groups.
+create table group_members (
+  group_id    uuid not null references groups(id) on delete cascade,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  player_id   uuid not null references players(id) on delete cascade,
+  joined_at   timestamptz not null default now(),
+  primary key (group_id, user_id)
+);
+
+create index group_members_user_idx on group_members(user_id);
+create index group_members_player_idx on group_members(player_id);
+
+-- Invite by email (used in #67).
+create table group_invites (
+  id              uuid primary key default gen_random_uuid(),
+  group_id        uuid not null references groups(id) on delete cascade,
+  invited_email   text not null,
+  token           text not null unique,
+  status          text not null default 'pending' check (status in ('pending','accepted','revoked','expired')),
+  expires_at      timestamptz,
+  created_at      timestamptz not null default now()
+);
+
+create index group_invites_group_idx on group_invites(group_id);
+
+-- Request-to-join (used in #68).
+create table group_join_requests (
+  id          uuid primary key default gen_random_uuid(),
+  group_id    uuid not null references groups(id) on delete cascade,
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  status      text not null default 'pending' check (status in ('pending','approved','rejected')),
+  created_at  timestamptz not null default now(),
+  unique (group_id, user_id)
+);
+
+-- Schema prep for #72/#73: nullable today, populated and NOT NULL later.
+alter table games add column group_id uuid references groups(id) on delete set null;
+create index games_group_id_idx on games(group_id);
+
+alter table encounter_scores add column group_id uuid references groups(id) on delete set null;
+create index encounter_scores_group_id_idx on encounter_scores(group_id);
+
+-- RLS
+alter table groups               enable row level security;
+alter table group_members        enable row level security;
+alter table group_invites        enable row level security;
+alter table group_join_requests  enable row level security;
+
+-- Helper: checks group membership without re-triggering RLS on group_members.
+-- SECURITY DEFINER bypasses RLS inside the function body, avoiding infinite recursion
+-- when policies on group_members / groups need to read group_members.
+create or replace function is_group_member(p_group_id uuid, p_user_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1 from group_members
+    where group_id = p_group_id and user_id = p_user_id
+  );
+$$;
+
+revoke all on function is_group_member(uuid, uuid) from public;
+grant execute on function is_group_member(uuid, uuid) to authenticated;
+
+-- groups: readable by members; admin can update/delete; any authed user can insert themselves as admin.
+create policy groups_select_members on groups
+  for select using (is_group_member(id, auth.uid()));
+
+create policy groups_insert_self_admin on groups
+  for insert with check (auth.uid() is not null and admin_user_id = auth.uid());
+
+create policy groups_update_admin on groups
+  for update using (admin_user_id = auth.uid()) with check (admin_user_id = auth.uid());
+
+create policy groups_delete_admin on groups
+  for delete using (admin_user_id = auth.uid());
+
+-- group_members: readable by any member of the same group; a user can insert their own membership;
+-- deletion allowed by the member themselves or by the group admin.
+create policy group_members_select_same_group on group_members
+  for select using (is_group_member(group_id, auth.uid()));
+
+create policy group_members_insert_self on group_members
+  for insert with check (user_id = auth.uid());
+
+create policy group_members_delete_self_or_admin on group_members
+  for delete using (
+    user_id = auth.uid()
+    or exists (select 1 from groups g where g.id = group_members.group_id and g.admin_user_id = auth.uid())
+  );
+
+-- group_invites: readable by group admin or by the invited email's user; writable by admin only.
+create policy group_invites_select_admin_or_target on group_invites
+  for select using (
+    exists (select 1 from groups g where g.id = group_invites.group_id and g.admin_user_id = auth.uid())
+    or invited_email = (select email from auth.users where id = auth.uid())
+  );
+
+create policy group_invites_insert_admin on group_invites
+  for insert with check (
+    exists (select 1 from groups g where g.id = group_invites.group_id and g.admin_user_id = auth.uid())
+  );
+
+create policy group_invites_update_admin on group_invites
+  for update using (
+    exists (select 1 from groups g where g.id = group_invites.group_id and g.admin_user_id = auth.uid())
+  );
+
+create policy group_invites_delete_admin on group_invites
+  for delete using (
+    exists (select 1 from groups g where g.id = group_invites.group_id and g.admin_user_id = auth.uid())
+  );
+
+-- group_join_requests: admin of the group and the requester can read; requester can insert;
+-- only admin can update status (approve/reject).
+create policy group_join_requests_select_admin_or_self on group_join_requests
+  for select using (
+    user_id = auth.uid()
+    or exists (select 1 from groups g where g.id = group_join_requests.group_id and g.admin_user_id = auth.uid())
+  );
+
+create policy group_join_requests_insert_self on group_join_requests
+  for insert with check (user_id = auth.uid());
+
+create policy group_join_requests_update_admin on group_join_requests
+  for update using (
+    exists (select 1 from groups g where g.id = group_join_requests.group_id and g.admin_user_id = auth.uid())
+  );
+
+create policy group_join_requests_delete_admin_or_self on group_join_requests
+  for delete using (
+    user_id = auth.uid()
+    or exists (select 1 from groups g where g.id = group_join_requests.group_id and g.admin_user_id = auth.uid())
+  );

--- a/supabase/migrations/20260420000200_groups_select_admin.sql
+++ b/supabase/migrations/20260420000200_groups_select_admin.sql
@@ -1,0 +1,11 @@
+-- Fix: creating a group via insert().select() fails because the SELECT RLS policy
+-- requires membership, but the group_members row isn't inserted until the next
+-- statement. Allow admins to select their own groups in addition to members.
+
+drop policy if exists groups_select_members on groups;
+
+create policy groups_select_member_or_admin on groups
+  for select using (
+    admin_user_id = auth.uid()
+    or is_group_member(id, auth.uid())
+  );


### PR DESCRIPTION
## Summary

Foundation for the Group system (umbrella #60). Bundles three sub-issues:

- **#63** Supabase magic-link auth, `/login`, `/auth/callback`, protected routing, `/setup` forced profile flow
- **#64** `groups`, `group_members`, `group_invites`, `group_join_requests` tables with RLS. Nullable `group_id` on `games` and `encounter_scores` (prep for #72/#73)
- **#65** `useGroups` + `useActiveGroup` hooks, `/groups/new`, group switcher in nav (Global option disabled until #71)

Plus one extra: enabled RLS on all 12 existing tables with permissive policies so RLS is always-on from this branch forward. Strict policies land per-table in later issues.

## Design notes

- One player per user. `players.user_id` FK to `auth.users`. Name UNIQUE dropped so two users can share a display name.
- `is_group_member` SECURITY DEFINER helper avoids RLS recursion on self-referential policies.
- Zero-group authenticated users still see Home/Leaderboard/Highscores/Stats/Counters (global aggregate) and only their own player on /players.
- On Players, editing is restricted to self — the name button and avatar are inert for other players.
- No legacy data claim flow — owner reassigns historic games manually post-launch (#74).

## Out of scope (deferred)

- Scoping games/counters/leaderboard/stats by active group (#71, #72, #73)
- Profile page strip (#70)
- Invite flows (#66, #67, #68)
- Admin panel (#69)
- Legacy data migration (#74)
- Tightening permissive RLS policies on legacy tables (will happen per-table in later issues)

## Test plan

- [ ] Fresh email → /login → magic link → /auth/callback → /setup → player created → redirect home
- [ ] Session persists across reloads
- [ ] Create group → switcher updates, localStorage set, reload persists
- [ ] Second test user joined to same group → both visible on /players
- [ ] Non-self players: name non-clickable, avatar button disabled
- [ ] Logout works; back-button does not leak past /login
- [ ] Pre-existing pages (Log Game, Leaderboard, Stats, Counters, Highscores, Tierlist) still load without regressions

Closes #63
Closes #64
Closes #65
Refs #60