### PR TITLE
feat(groups): invites by link and email (#66 #67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ npm run lint      # eslint
 
 **House Rules** is a chooser landing at `/house-rules` with two sub-pages: `/house-rules/rules` (the fellowship's house-rules text, from `HOUSE_RULES` in `src/data/houseRules.js`) and `/house-rules/rulebooks` (official PDFs grouped by core/corner/small, from `RULEBOOKS` in the same file). Each rulebook entry carries `slug`, `subtitle`, `type` (`pdf`/`web`), `group`, and `icon` — the icon key maps to an inline SVG defined in `Rulebooks.jsx`.
 
+**Group invites.** `/groups/:id/settings` is the admin surface for invite management (copy/regenerate link, send email-style invites, revoke/history). `/join/:code` is the public link-join page — it resolves the code via the `get_group_by_invite_code` RPC and short-circuits existing members. `PendingInvitesBanner` mounts inside `Layout` and surfaces email-style invites to the invitee with Accept/Decline (session-scoped dismiss via `sessionStorage`). Magic-link auth supports `?next=` via `sanitizeNext` in `src/utils/redirect.js`; `ProtectedRoute` preserves the current path on unauth redirect, and `AuthCallback` honors the sanitized `next` after session resolves.
+
 ## Database
 
 Tables: `players`, `characters` (seed), `endings` (seed), `games`, `game_players`, `game_highscores`, `game_expansion_events`, `icons` (seed, characters + Toad), `encounter_scores`, `tierlists`. Full schema in `EDD.md`.
@@ -50,6 +52,8 @@ Tables: `players`, `characters` (seed), `endings` (seed), `games`, `game_players
 **Tierlists** are per-player and stored as a single JSONB column (`{S:[],A:[],B:[],C:[],D:[],F:[]}` of icon keys) on the `tierlists` table with a unique `player_id`. The Tierlist page (`/players/:id/tierlist`) sources characters from the `icons` table (so Toad is rankable) and filters dangling keys on load. Drag/drop uses HTML5 native DnD — no third-party library.
 
 Migrations live in `supabase/migrations/` and are applied via Supabase CLI. Seed data (characters, endings) is included in the initial migration.
+
+**`group_invites` hygiene.** Emails are stored case-insensitive (CHECK `invited_email = lower(...)`). A partial unique index on `(group_id, invited_email) WHERE status='pending'` enforces one pending invite per email per group — admin re-invites update the existing row rather than inserting a duplicate. `expires_at` is NOT NULL with a 7-day default. Two RPCs back the invite flow: `accept_group_invite(p_token)` (SECURITY DEFINER, atomically verifies the invite, inserts the `group_members` row, marks the invite accepted, returns the group_id) and `get_group_by_invite_code(p_code)` (resolves a link code to `(id, name)` without widening the `groups` select policy).
 
 ### Supabase workflow
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Login from './pages/Login'
 import AuthCallback from './pages/AuthCallback'
 import Setup from './pages/Setup'
 import CreateGroup from './pages/CreateGroup'
+import GroupSettings from './pages/GroupSettings'
 import Home from './pages/Home'
 import LogGame from './pages/LogGame'
 import EditGame from './pages/EditGame'
@@ -45,6 +46,7 @@ export default function App() {
             <Route element={<ProtectedLayout />}>
               <Route path="/setup" element={<Setup />} />
               <Route path="/groups/new" element={<CreateGroup />} />
+              <Route path="/groups/:id/settings" element={<GroupSettings />} />
               <Route path="/" element={<Home />} />
               <Route path="/log" element={<LogGame />} />
               <Route path="/games/:id/edit" element={<EditGame />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import AuthCallback from './pages/AuthCallback'
 import Setup from './pages/Setup'
 import CreateGroup from './pages/CreateGroup'
 import GroupSettings from './pages/GroupSettings'
+import JoinGroup from './pages/JoinGroup'
 import Home from './pages/Home'
 import LogGame from './pages/LogGame'
 import EditGame from './pages/EditGame'
@@ -47,6 +48,7 @@ export default function App() {
               <Route path="/setup" element={<Setup />} />
               <Route path="/groups/new" element={<CreateGroup />} />
               <Route path="/groups/:id/settings" element={<GroupSettings />} />
+              <Route path="/join/:code" element={<JoinGroup />} />
               <Route path="/" element={<Home />} />
               <Route path="/log" element={<LogGame />} />
               <Route path="/games/:id/edit" element={<EditGame />} />

--- a/src/components/GroupSwitcher.jsx
+++ b/src/components/GroupSwitcher.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useActiveGroup } from '../hooks/useActiveGroup'
+import { useAuth } from '../hooks/useAuth'
 
 export default function GroupSwitcher({ onNavigate }) {
   const { activeGroup, groups, setActiveGroup } = useActiveGroup()
+  const { user } = useAuth()
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
   const containerRef = useRef(null)
@@ -71,6 +73,19 @@ export default function GroupSwitcher({ onNavigate }) {
           >
             Global (disabled)
           </button>
+          {activeGroup && activeGroup.admin_user_id === user?.id && (
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false)
+                onNavigate?.()
+                navigate(`/groups/${activeGroup.id}/settings`)
+              }}
+              className="w-full text-left px-3 py-2 text-sm font-heading text-parchment hover:bg-gold/5 border-t border-gold-dim/20"
+            >
+              Group settings
+            </button>
+          )}
           <div className="border-t border-gold-dim/20" />
           <button
             type="button"

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import GroupSwitcher from './GroupSwitcher'
+import PendingInvitesBanner from './PendingInvitesBanner'
 
 const NAV_LINKS = [
   { to: '/', label: 'Home' },
@@ -139,6 +140,7 @@ export default function Layout({ children }) {
 
       {/* Page content */}
       <main className="flex-1 pt-16">
+        <PendingInvitesBanner />
         {children}
       </main>
 

--- a/src/components/PendingInvitesBanner.jsx
+++ b/src/components/PendingInvitesBanner.jsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import { usePendingInvites } from '../hooks/usePendingInvites'
+import { useAcceptInvite, useDeclineInvite } from '../hooks/useAcceptInvite'
+
+function dismissKey(userId) {
+  return `pendingInvitesDismissed:${userId ?? 'anon'}`
+}
+
+export default function PendingInvitesBanner() {
+  const { user } = useAuth()
+  const { data: invites = [] } = usePendingInvites()
+  const { setActiveGroup } = useActiveGroup()
+  const accept = useAcceptInvite()
+  const decline = useDeclineInvite()
+  const navigate = useNavigate()
+
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return sessionStorage.getItem(dismissKey(user?.id)) === '1'
+  })
+
+  if (dismissed || invites.length === 0) return null
+
+  const onAccept = async (invite) => {
+    try {
+      const groupId = await accept.mutateAsync(invite.token)
+      setActiveGroup(groupId)
+      navigate('/', { replace: true })
+    } catch (e) {
+      // Surface the Postgres exception name back to the user; banner will re-render.
+      alert(`Couldn't accept invite: ${e.message}`)
+    }
+  }
+
+  return (
+    <div className="bg-gold/10 border-b border-gold-dim/40 px-4 py-3">
+      <div className="max-w-4xl mx-auto flex items-start justify-between gap-4">
+        <ul className="flex-1 space-y-2">
+          {invites.map((inv) => (
+            <li key={inv.id} className="flex items-center justify-between gap-3">
+              <span className="text-parchment">
+                <span className="font-heading text-gold">{inv.groups?.name ?? 'A group'}</span> invited you to join.
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onAccept(inv)}
+                  disabled={accept.isPending}
+                  className="px-3 py-1 bg-gold text-deep font-heading rounded text-sm hover:bg-gold-light transition-colors"
+                >
+                  Accept
+                </button>
+                <button
+                  type="button"
+                  onClick={() => decline.mutate(inv.id)}
+                  disabled={decline.isPending}
+                  className="px-3 py-1 border border-gold-dim/40 text-parchment font-heading rounded text-sm hover:text-gold transition-colors"
+                >
+                  Decline
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <button
+          type="button"
+          onClick={() => {
+            sessionStorage.setItem(dismissKey(user?.id), '1')
+            setDismissed(true)
+          }}
+          className="text-parchment/60 hover:text-gold text-sm"
+          aria-label="Dismiss for this session"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PendingInvitesBanner.jsx
+++ b/src/components/PendingInvitesBanner.jsx
@@ -42,7 +42,7 @@ export default function PendingInvitesBanner() {
           {invites.map((inv) => (
             <li key={inv.id} className="flex items-center justify-between gap-3">
               <span className="text-parchment">
-                <span className="font-heading text-gold">{inv.groups?.name ?? 'A group'}</span> invited you to join.
+                <span className="font-heading text-gold">{inv.group_name ?? 'A group'}</span> invited you to join.
               </span>
               <div className="flex gap-2">
                 <button

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -16,7 +16,9 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (!user) {
-    return <Navigate to="/login" state={{ from: location }} replace />
+    const next = location.pathname + location.search
+    const qs = next && next !== '/' ? `?next=${encodeURIComponent(next)}` : ''
+    return <Navigate to={`/login${qs}`} replace />
   }
 
   if (!player && location.pathname !== '/setup') {

--- a/src/hooks/useAcceptInvite.js
+++ b/src/hooks/useAcceptInvite.js
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from './useAuth'
+
+export function useAcceptInvite() {
+  const qc = useQueryClient()
+  const { user } = useAuth()
+  return useMutation({
+    mutationFn: async (token) => {
+      const { data, error } = await supabase.rpc('accept_group_invite', { p_token: token })
+      if (error) throw error
+      return data  // group_id
+    },
+    onSuccess: (groupId) => {
+      qc.invalidateQueries({ queryKey: ['groups', user?.id] })
+      qc.invalidateQueries({ queryKey: ['pendingInvites', user?.id] })
+      qc.invalidateQueries({ queryKey: ['groupMembers', groupId] })
+    },
+  })
+}
+
+export function useDeclineInvite() {
+  const qc = useQueryClient()
+  const { user } = useAuth()
+  return useMutation({
+    mutationFn: async (inviteId) => {
+      const { error } = await supabase
+        .from('group_invites')
+        .update({ status: 'revoked' })
+        .eq('id', inviteId)
+      if (error) throw error
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['pendingInvites', user?.id] }),
+  })
+}

--- a/src/hooks/useGroupInvites.js
+++ b/src/hooks/useGroupInvites.js
@@ -1,0 +1,106 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+
+// Reads all invites for a group (admin only, enforced by RLS).
+// includeHistory=true extends to revoked/accepted/expired in the last 30 days.
+export function useGroupInvites(groupId, { includeHistory = false } = {}) {
+  return useQuery({
+    queryKey: ['groupInvites', groupId, includeHistory],
+    enabled: !!groupId,
+    queryFn: async () => {
+      let q = supabase
+        .from('group_invites')
+        .select('id, invited_email, status, expires_at, created_at')
+        .eq('group_id', groupId)
+        .order('created_at', { ascending: false })
+      if (!includeHistory) {
+        q = q.eq('status', 'pending')
+      } else {
+        const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+        q = q.gte('created_at', cutoff)
+      }
+      const { data, error } = await q
+      if (error) throw error
+      return data
+    },
+  })
+}
+
+function newToken() {
+  const bytes = crypto.getRandomValues(new Uint8Array(24))
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// Upsert-by-hand: SELECT existing pending row -> UPDATE or INSERT.
+// Avoids ON CONFLICT against a partial unique index.
+export function useCreateEmailInvite(groupId) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (rawEmail) => {
+      const email = rawEmail.trim().toLowerCase()
+      const token = newToken()
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+
+      const { data: existing, error: selErr } = await supabase
+        .from('group_invites')
+        .select('id')
+        .eq('group_id', groupId)
+        .eq('invited_email', email)
+        .eq('status', 'pending')
+        .maybeSingle()
+      if (selErr) throw selErr
+
+      if (existing) {
+        const { error: updErr } = await supabase
+          .from('group_invites')
+          .update({ token, expires_at: expiresAt })
+          .eq('id', existing.id)
+        if (updErr) throw updErr
+      } else {
+        const { error: insErr } = await supabase
+          .from('group_invites')
+          .insert({ group_id: groupId, invited_email: email, token, status: 'pending', expires_at: expiresAt })
+        if (insErr) throw insErr
+      }
+      return email
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['groupInvites', groupId] }),
+  })
+}
+
+export function useRevokeInvite(groupId) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (inviteId) => {
+      const { error } = await supabase
+        .from('group_invites')
+        .update({ status: 'revoked' })
+        .eq('id', inviteId)
+      if (error) throw error
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['groupInvites', groupId] }),
+  })
+}
+
+function newInviteCode() {
+  const bytes = crypto.getRandomValues(new Uint8Array(8))
+  return Array.from(bytes, (b) => b.toString(36).padStart(2, '0')).join('').slice(0, 12)
+}
+
+export function useRegenerateInviteCode(groupId) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      const code = newInviteCode()
+      const { error } = await supabase
+        .from('groups')
+        .update({ invite_code: code })
+        .eq('id', groupId)
+      if (error) throw error
+      return code
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['groups'] })
+    },
+  })
+}

--- a/src/hooks/useJoinByCode.js
+++ b/src/hooks/useJoinByCode.js
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from './useAuth'
+
+// Resolves a code to a group; caller supplies player_id since the hook shouldn't
+// re-query it (useCurrentPlayer is already cached in the page).
+export async function lookupGroupByCode(code) {
+  const { data, error } = await supabase.rpc('get_group_by_invite_code', { p_code: code })
+  if (error) throw error
+  return data?.[0] ?? null
+}
+
+export function useJoinByCode() {
+  const qc = useQueryClient()
+  const { user } = useAuth()
+  return useMutation({
+    mutationFn: async ({ groupId, playerId }) => {
+      const { error } = await supabase
+        .from('group_members')
+        .insert({ group_id: groupId, user_id: user.id, player_id: playerId })
+      if (error && error.code !== '23505') throw error  // unique_violation = already a member, tolerate
+    },
+    onSuccess: (_data, { groupId }) => {
+      qc.invalidateQueries({ queryKey: ['groups', user?.id] })
+      qc.invalidateQueries({ queryKey: ['groupMembers', groupId] })
+    },
+  })
+}

--- a/src/hooks/usePendingInvites.js
+++ b/src/hooks/usePendingInvites.js
@@ -4,22 +4,16 @@ import { useAuth } from './useAuth'
 import { useCurrentPlayer } from './useCurrentPlayer'
 
 // Invites addressed to the current user's email, pending, not expired.
-// Explicit invited_email filter — RLS admin branch would otherwise leak
-// every invite on the admin's groups into their own pending list.
+// Uses a SECURITY DEFINER RPC so the group name comes back even though the
+// invitee isn't a group member yet (the groups select policy is members-only).
 export function usePendingInvites() {
   const { user } = useAuth()
   const { data: player } = useCurrentPlayer()
-  const email = user?.email?.toLowerCase() ?? null
   return useQuery({
     queryKey: ['pendingInvites', user?.id],
-    enabled: !!user && !!player && !!email,
+    enabled: !!user && !!player,
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('group_invites')
-        .select('id, token, group_id, expires_at, groups(name)')
-        .eq('invited_email', email)
-        .eq('status', 'pending')
-        .gt('expires_at', new Date().toISOString())
+      const { data, error } = await supabase.rpc('get_pending_invites_for_me')
       if (error) throw error
       return data
     },

--- a/src/hooks/usePendingInvites.js
+++ b/src/hooks/usePendingInvites.js
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from './useAuth'
+import { useCurrentPlayer } from './useCurrentPlayer'
+
+// Invites addressed to the current user's email, pending, not expired.
+// RLS already filters by email+status+expires_at — query stays simple.
+export function usePendingInvites() {
+  const { user } = useAuth()
+  const { data: player } = useCurrentPlayer()
+  return useQuery({
+    queryKey: ['pendingInvites', user?.id],
+    enabled: !!user && !!player,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('group_invites')
+        .select('id, token, group_id, expires_at, groups(name)')
+        .eq('status', 'pending')
+        .gt('expires_at', new Date().toISOString())
+      if (error) throw error
+      return data
+    },
+  })
+}

--- a/src/hooks/usePendingInvites.js
+++ b/src/hooks/usePendingInvites.js
@@ -4,17 +4,20 @@ import { useAuth } from './useAuth'
 import { useCurrentPlayer } from './useCurrentPlayer'
 
 // Invites addressed to the current user's email, pending, not expired.
-// RLS already filters by email+status+expires_at — query stays simple.
+// Explicit invited_email filter — RLS admin branch would otherwise leak
+// every invite on the admin's groups into their own pending list.
 export function usePendingInvites() {
   const { user } = useAuth()
   const { data: player } = useCurrentPlayer()
+  const email = user?.email?.toLowerCase() ?? null
   return useQuery({
     queryKey: ['pendingInvites', user?.id],
-    enabled: !!user && !!player,
+    enabled: !!user && !!player && !!email,
     queryFn: async () => {
       const { data, error } = await supabase
         .from('group_invites')
         .select('id, token, group_id, expires_at, groups(name)')
+        .eq('invited_email', email)
         .eq('status', 'pending')
         .gt('expires_at', new Date().toISOString())
       if (error) throw error

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,16 +1,22 @@
 import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
+import { sanitizeNext } from '../utils/redirect'
 
 export default function AuthCallback() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
-      if (data.session) navigate('/', { replace: true })
-      else navigate('/login', { replace: true })
+      if (data.session) {
+        const next = sanitizeNext(searchParams.get('next'))
+        navigate(next, { replace: true })
+      } else {
+        navigate('/login', { replace: true })
+      }
     })
-  }, [navigate])
+  }, [navigate, searchParams])
 
   return (
     <div className="min-h-screen flex items-center justify-center text-parchment bg-deep">

--- a/src/pages/GroupSettings.jsx
+++ b/src/pages/GroupSettings.jsx
@@ -1,0 +1,175 @@
+import { useState } from 'react'
+import { useParams, Navigate } from 'react-router-dom'
+import { useForm } from 'react-hook-form'
+import { useAuth } from '../hooks/useAuth'
+import { useGroups } from '../hooks/useGroups'
+import {
+  useGroupInvites,
+  useCreateEmailInvite,
+  useRevokeInvite,
+  useRegenerateInviteCode,
+} from '../hooks/useGroupInvites'
+
+function relativeExpiry(iso) {
+  const diff = new Date(iso).getTime() - Date.now()
+  if (diff <= 0) return 'expired'
+  const days = Math.floor(diff / (24 * 60 * 60 * 1000))
+  if (days >= 1) return `${days}d left`
+  const hours = Math.max(1, Math.floor(diff / (60 * 60 * 1000)))
+  return `${hours}h left`
+}
+
+export default function GroupSettings() {
+  const { id: groupId } = useParams()
+  const { user } = useAuth()
+  const { data: groups = [], isLoading: groupsLoading } = useGroups()
+  const group = groups.find((g) => g.id === groupId)
+
+  const [showHistory, setShowHistory] = useState(false)
+  const { data: invites = [], isLoading: invitesLoading } = useGroupInvites(groupId, { includeHistory: showHistory })
+  const createInvite = useCreateEmailInvite(groupId)
+  const revokeInvite = useRevokeInvite(groupId)
+  const regenerate = useRegenerateInviteCode(groupId)
+
+  const { register, handleSubmit, reset, formState: { errors } } = useForm()
+  const [formError, setFormError] = useState(null)
+  const [toast, setToast] = useState(null)
+
+  if (groupsLoading) return <div className="p-8 text-parchment/60">Loading…</div>
+  if (!group) return <Navigate to="/" replace />
+  if (group.admin_user_id !== user?.id) return <Navigate to="/" replace />
+
+  const joinUrl = `${window.location.origin}/join/${group.invite_code}`
+
+  const onCopy = async () => {
+    await navigator.clipboard.writeText(joinUrl)
+    setToast('Link copied.')
+    setTimeout(() => setToast(null), 2000)
+  }
+
+  const onRegenerate = async () => {
+    if (!window.confirm('Regenerate the invite link? The old link will stop working.')) return
+    await regenerate.mutateAsync()
+    setToast('New link generated.')
+    setTimeout(() => setToast(null), 2000)
+  }
+
+  const onInvite = handleSubmit(async ({ email }) => {
+    setFormError(null)
+    const normalized = email.trim().toLowerCase()
+
+    // Q8-c: block self-invite by admin.
+    if (user?.email?.toLowerCase() === normalized) {
+      setFormError("That's you — you're the admin.")
+      return
+    }
+
+    try {
+      await createInvite.mutateAsync(normalized)
+      reset({ email: '' })
+      setToast('Invite created — user will see it next time they log in.')
+      setTimeout(() => setToast(null), 3000)
+    } catch (e) {
+      setFormError(e.message ?? 'Failed to create invite.')
+    }
+  })
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8 space-y-10">
+      <header className="space-y-1">
+        <h1 className="font-display text-3xl text-gold tracking-wider">{group.name}</h1>
+        <p className="text-parchment/60 font-body text-sm">Group settings</p>
+      </header>
+
+      {toast && <div className="px-4 py-2 bg-gold/10 border border-gold-dim/40 rounded text-parchment">{toast}</div>}
+
+      <section className="space-y-3">
+        <h2 className="font-heading text-xl text-parchment">Invite link</h2>
+        <p className="text-parchment/70 text-sm font-body">Anyone with this link can join the group.</p>
+        <div className="flex gap-2">
+          <input
+            readOnly
+            value={joinUrl}
+            className="flex-1 px-3 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded text-sm"
+          />
+          <button
+            type="button"
+            onClick={onCopy}
+            className="px-4 py-2 bg-gold text-deep font-heading rounded hover:bg-gold-light transition-colors"
+          >
+            Copy
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={onRegenerate}
+          disabled={regenerate.isPending}
+          className="text-sm text-parchment/70 hover:text-gold underline"
+        >
+          {regenerate.isPending ? 'Regenerating…' : 'Regenerate link'}
+        </button>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-heading text-xl text-parchment">Invite by email</h2>
+        <form onSubmit={onInvite} className="flex gap-2">
+          <input
+            type="email"
+            placeholder="friend@example.com"
+            {...register('email', { required: 'Email required' })}
+            className="flex-1 px-3 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded"
+          />
+          <button
+            type="submit"
+            disabled={createInvite.isPending}
+            className="px-4 py-2 bg-gold text-deep font-heading rounded hover:bg-gold-light transition-colors"
+          >
+            {createInvite.isPending ? 'Sending…' : 'Send invite'}
+          </button>
+        </form>
+        {errors.email && <p className="text-red-400 text-sm">{errors.email.message}</p>}
+        {formError && <p className="text-red-400 text-sm">{formError}</p>}
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-heading text-xl text-parchment">{showHistory ? 'All invites (30d)' : 'Pending invites'}</h2>
+          <button
+            type="button"
+            onClick={() => setShowHistory((s) => !s)}
+            className="text-sm text-parchment/70 hover:text-gold underline"
+          >
+            {showHistory ? 'Show pending only' : 'Show revoked/accepted'}
+          </button>
+        </div>
+        {invitesLoading ? (
+          <p className="text-parchment/50 text-sm">Loading…</p>
+        ) : invites.length === 0 ? (
+          <p className="text-parchment/50 text-sm italic">No {showHistory ? 'invites' : 'pending invites'}.</p>
+        ) : (
+          <ul className="divide-y divide-gold-dim/20 border border-gold-dim/20 rounded">
+            {invites.map((inv) => (
+              <li key={inv.id} className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <div className="text-parchment">{inv.invited_email}</div>
+                  <div className="text-xs text-parchment/50 font-body">
+                    {inv.status === 'pending' ? relativeExpiry(inv.expires_at) : inv.status}
+                  </div>
+                </div>
+                {inv.status === 'pending' && (
+                  <button
+                    type="button"
+                    onClick={() => revokeInvite.mutate(inv.id)}
+                    className="text-sm text-red-300 hover:text-red-200 underline"
+                  >
+                    Revoke
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/src/pages/JoinGroup.jsx
+++ b/src/pages/JoinGroup.jsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { supabase } from '../supabaseClient'
+import { useAuth } from '../hooks/useAuth'
+import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import { lookupGroupByCode, useJoinByCode } from '../hooks/useJoinByCode'
+
+export default function JoinGroup() {
+  const { code } = useParams()
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const { data: player } = useCurrentPlayer()
+  const { setActiveGroup } = useActiveGroup()
+  const joinByCode = useJoinByCode()
+
+  const [status, setStatus] = useState('loading')  // loading | confirm | invalid | joining | done
+  const [group, setGroup] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const g = await lookupGroupByCode(code)
+        if (cancelled) return
+        if (!g) { setStatus('invalid'); return }
+        setGroup(g)
+
+        const { data: existing, error: memErr } = await supabase
+          .from('group_members')
+          .select('group_id')
+          .eq('group_id', g.id)
+          .eq('user_id', user.id)
+          .maybeSingle()
+        if (memErr) throw memErr
+
+        if (existing) {
+          setActiveGroup(g.id)
+          navigate('/', { replace: true })
+          return
+        }
+        setStatus('confirm')
+      } catch (e) {
+        if (!cancelled) { setError(e.message); setStatus('invalid') }
+      }
+    })()
+    return () => { cancelled = true }
+  }, [code, user?.id, navigate, setActiveGroup])
+
+  const onJoin = async () => {
+    if (!player) {
+      navigate(`/setup?next=/join/${code}`, { replace: true })
+      return
+    }
+    setStatus('joining')
+    try {
+      await joinByCode.mutateAsync({ groupId: group.id, playerId: player.id })
+      setActiveGroup(group.id)
+      setStatus('done')
+      navigate('/', { replace: true })
+    } catch (e) {
+      setError(e.message)
+      setStatus('confirm')
+    }
+  }
+
+  if (status === 'loading') {
+    return <div className="p-8 text-parchment/60">Loading…</div>
+  }
+  if (status === 'invalid') {
+    return (
+      <div className="max-w-md mx-auto mt-16 px-4 space-y-4">
+        <h1 className="font-display text-2xl text-gold">Invalid invite link</h1>
+        <p className="text-parchment/70 font-body">This link is no longer valid. Ask your group admin for a new one.</p>
+        {error && <p className="text-red-400 text-sm">{error}</p>}
+      </div>
+    )
+  }
+  return (
+    <div className="max-w-md mx-auto mt-16 px-4 space-y-4">
+      <h1 className="font-display text-2xl text-gold">Join {group.name}?</h1>
+      <p className="text-parchment/70 font-body">You'll join as a member of this group.</p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onJoin}
+          disabled={status === 'joining'}
+          className="px-4 py-2 bg-gold text-deep font-heading rounded hover:bg-gold-light transition-colors"
+        >
+          {status === 'joining' ? 'Joining…' : 'Join'}
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('/', { replace: true })}
+          className="px-4 py-2 border border-gold-dim/40 text-parchment font-heading rounded hover:text-gold hover:border-gold-dim transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="text-red-400 text-sm">{error}</p>}
+    </div>
+  )
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,16 +1,20 @@
 import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
+import { sanitizeNext } from '../utils/redirect'
 
 export default function Login() {
   const [email, setEmail] = useState('')
   const [status, setStatus] = useState('idle')
   const [error, setError] = useState(null)
+  const [searchParams] = useSearchParams()
+  const next = sanitizeNext(searchParams.get('next'))
 
   const onSubmit = async (e) => {
     e.preventDefault()
     setStatus('sending')
     setError(null)
-    const redirectUrl = `${window.location.origin}/auth/callback`
+    const redirectUrl = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: { emailRedirectTo: redirectUrl },

--- a/src/utils/redirect.js
+++ b/src/utils/redirect.js
@@ -1,0 +1,11 @@
+// Returns a safe same-origin relative path, or '/' if input is unsafe.
+// Accepts: strings starting with '/', not starting with '//', no ':' before the first '/'.
+export function sanitizeNext(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return '/'
+  if (!raw.startsWith('/')) return '/'
+  if (raw.startsWith('//')) return '/'
+  const firstSlash = raw.indexOf('/', 1)
+  const head = firstSlash === -1 ? raw.slice(1) : raw.slice(1, firstSlash)
+  if (head.includes(':')) return '/'
+  return raw
+}

--- a/supabase/migrations/20260420010000_invite_constraints.sql
+++ b/supabase/migrations/20260420010000_invite_constraints.sql
@@ -1,0 +1,34 @@
+-- Case-insensitive storage for invited emails.
+alter table group_invites
+  add constraint group_invites_email_lowercase
+  check (invited_email = lower(invited_email));
+
+-- One pending invite per (group, email). Admin re-invite updates the existing row.
+create unique index group_invites_one_pending_per_email
+  on group_invites (group_id, invited_email)
+  where status = 'pending';
+
+-- Default 7-day expiry; backfill, then NOT NULL.
+alter table group_invites
+  alter column expires_at set default (now() + interval '7 days');
+update group_invites set expires_at = now() + interval '7 days' where expires_at is null;
+alter table group_invites alter column expires_at set not null;
+
+-- Target-side select: case-insensitive, pending-only, non-expired.
+drop policy group_invites_select_admin_or_target on group_invites;
+create policy group_invites_select_admin_or_target on group_invites
+  for select using (
+    exists (select 1 from groups g where g.id = group_invites.group_id and g.admin_user_id = auth.uid())
+    or (
+      invited_email = lower((select email from auth.users where id = auth.uid()))
+      and status = 'pending'
+      and expires_at > now()
+    )
+  );
+
+-- Decline: the target user may flip their own pending invite to revoked.
+create policy group_invites_update_target_decline on group_invites
+  for update using (
+    invited_email = lower((select email from auth.users where id = auth.uid()))
+    and status = 'pending'
+  ) with check (status = 'revoked');

--- a/supabase/migrations/20260420010100_invite_rpcs.sql
+++ b/supabase/migrations/20260420010100_invite_rpcs.sql
@@ -1,0 +1,59 @@
+-- Atomic: verify invite → insert group_members → mark invite accepted.
+create or replace function accept_group_invite(p_token text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite   group_invites%rowtype;
+  v_user_id  uuid := auth.uid();
+  v_email    text;
+  v_player   uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated'; end if;
+
+  select email into v_email from auth.users where id = v_user_id;
+  select * into v_invite from group_invites where token = p_token for update;
+
+  if not found then raise exception 'invite_not_found'; end if;
+  if v_invite.status <> 'pending' then raise exception 'invite_not_pending'; end if;
+  if v_invite.expires_at <= now() then raise exception 'invite_expired'; end if;
+  if v_invite.invited_email <> lower(v_email) then raise exception 'invite_email_mismatch'; end if;
+
+  select id into v_player from players where user_id = v_user_id;
+  if v_player is null then raise exception 'no_player_profile'; end if;
+
+  insert into group_members (group_id, user_id, player_id)
+    values (v_invite.group_id, v_user_id, v_player)
+    on conflict (group_id, user_id) do nothing;
+
+  update group_invites set status = 'accepted' where id = v_invite.id;
+
+  update group_invites
+    set status = 'accepted'
+    where group_id = v_invite.group_id
+      and invited_email = lower(v_email)
+      and status = 'pending'
+      and id <> v_invite.id;
+
+  return v_invite.group_id;
+end;
+$$;
+
+revoke all on function accept_group_invite(text) from public;
+grant execute on function accept_group_invite(text) to authenticated;
+
+-- Link-lookup: resolve invite_code → (id, name) without widening the groups select policy.
+create or replace function get_group_by_invite_code(p_code text)
+returns table(id uuid, name text)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select id, name from groups where invite_code = p_code;
+$$;
+
+revoke all on function get_group_by_invite_code(text) from public;
+grant execute on function get_group_by_invite_code(text) to authenticated;

--- a/supabase/migrations/20260421120000_invite_policies_use_jwt_email.sql
+++ b/supabase/migrations/20260421120000_invite_policies_use_jwt_email.sql
@@ -1,0 +1,24 @@
+-- The previous select/update policies called `select email from auth.users`,
+-- which executes with the caller's privileges and fails with "permission
+-- denied for table users" for regular authenticated clients. The failing
+-- subquery also poisons the admin branch of the OR, so admins got 403 too.
+-- Replace with auth.jwt() ->> 'email', which reads from JWT claims and
+-- requires no table permissions.
+
+drop policy if exists group_invites_select_admin_or_target on group_invites;
+create policy group_invites_select_admin_or_target on group_invites
+  for select using (
+    exists (select 1 from groups g where g.id = group_invites.group_id and g.admin_user_id = auth.uid())
+    or (
+      invited_email = lower(auth.jwt() ->> 'email')
+      and status = 'pending'
+      and expires_at > now()
+    )
+  );
+
+drop policy if exists group_invites_update_target_decline on group_invites;
+create policy group_invites_update_target_decline on group_invites
+  for update using (
+    invited_email = lower(auth.jwt() ->> 'email')
+    and status = 'pending'
+  ) with check (status = 'revoked');

--- a/supabase/migrations/20260421140000_pending_invites_rpc.sql
+++ b/supabase/migrations/20260421140000_pending_invites_rpc.sql
@@ -1,0 +1,29 @@
+-- usePendingInvites needs the group name, but the `groups` select policy is
+-- members-only — pending invitees aren't members yet, so the embedded
+-- groups(name) join comes back null. SECURITY DEFINER function returns the
+-- join result scoped to the caller's email without widening any policy.
+
+create or replace function get_pending_invites_for_me()
+returns table (
+  id uuid,
+  token text,
+  group_id uuid,
+  expires_at timestamptz,
+  group_name text
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select gi.id, gi.token, gi.group_id, gi.expires_at, g.name as group_name
+  from group_invites gi
+  join groups g on g.id = gi.group_id
+  where gi.invited_email = lower(auth.jwt() ->> 'email')
+    and gi.status = 'pending'
+    and gi.expires_at > now()
+  order by gi.created_at desc;
+$$;
+
+revoke all on function get_pending_invites_for_me() from public;
+grant execute on function get_pending_invites_for_me() to authenticated;


### PR DESCRIPTION
## Summary
Adds group-invite flows: admin settings page for link + email invites, `/join/:code` public link page, and an in-app pending-invites banner for email-style invites. Magic-link auth now honours `?next=` so protected routes survive the login round-trip. Closes #66 and #67.

## Changes
- **DB**: `group_invites` hygiene (case-insensitive emails, partial unique index on pending per (group, email), NOT NULL 7-day `expires_at`, target-side select/decline policies using `auth.jwt() -> 'email'`).
- **DB**: SECURITY DEFINER RPCs — `accept_group_invite` (atomic accept), `get_group_by_invite_code` (link lookup without widening groups select), `get_pending_invites_for_me` (invitee banner data without widening groups select).
- **Auth**: `sanitizeNext` util; `ProtectedRoute` preserves current path on unauth redirect; `Login` forwards `next` into the magic-link email; `AuthCallback` navigates to the sanitized `next` post-session.
- **UI**: `/groups/:id/settings` (copy/regenerate link, email invite form, pending + 30d history with revoke); `/join/:code` (confirm-to-join, short-circuits existing members, routes unprofiled users to `/setup?next=`); `PendingInvitesBanner` mounted in `Layout` with accept/decline/dismiss.
- **Hooks**: `useGroupInvites`, `useCreateEmailInvite`, `useRevokeInvite`, `useRegenerateInviteCode`, `usePendingInvites`, `useAcceptInvite`, `useDeclineInvite`, `useJoinByCode` + `lookupGroupByCode`.
- **Docs**: `CLAUDE.md` updated with invite surfaces, RPCs, and `?next=` plumbing.

Design spec: \`docs/superpowers/specs/2026-04-20-group-invites-design.md\`. Plan: \`docs/superpowers/plans/2026-04-20-group-invites.md\`.

## Test plan
- [x] Admin can copy link, regenerate, send email invite, revoke, toggle history.
- [x] Link flow: logged-out `/join/:code` → `/login?next=...` → magic link → back to `/join/:code` → join → active group set.
- [x] Email flow: invitee sees banner with correct group name, accepts/declines cleanly.
- [x] Admin's own banner does not leak outgoing invites (scoped to caller email).
- [x] RLS doesn't 403 admin listing (uses JWT email, not `auth.users`).