### PR TITLE
fix: refresh group-scoped pages when active group changes

### DIFF
--- a/src/components/GroupSwitcher.jsx
+++ b/src/components/GroupSwitcher.jsx
@@ -51,7 +51,7 @@ export default function GroupSwitcher({ onNavigate }) {
         {label} <span aria-hidden="true">▾</span>
       </button>
       {open && (
-        <div className="absolute right-0 mt-2 w-56 bg-deep border border-gold-dim/40 rounded shadow-lg z-50 overflow-hidden">
+        <div className="absolute left-0 mt-2 w-56 bg-deep border border-gold-dim/40 rounded shadow-lg z-50 overflow-hidden">
           {groups.length === 0 && (
             <div className="px-3 py-2 text-xs text-parchment/50 font-body italic">
               You're not in any groups yet.
@@ -71,14 +71,6 @@ export default function GroupSwitcher({ onNavigate }) {
               {g.name}
             </button>
           ))}
-          <button
-            type="button"
-            disabled
-            title="Global view — coming soon"
-            className="w-full text-left px-3 py-2 text-sm font-heading text-parchment/40 cursor-not-allowed"
-          >
-            Global (disabled)
-          </button>
           {activeGroup && isAdmin && (
             <button
               type="button"

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -59,7 +59,7 @@ export default function Layout({ children }) {
           <div className="flex items-center justify-between h-16">
             {/* Left: group switcher + logo */}
             <div className="flex items-center gap-3">
-              {user && <span className="hidden md:block"><GroupSwitcher /></span>}
+              {user && <div className="hidden md:block"><GroupSwitcher /></div>}
               <Link to="/" className="flex items-center gap-2.5 text-gold hover:text-gold-light transition-colors">
                 <img src="/icons/talisman-logo.png" alt="" className="w-8 h-8" />
                 <span className="font-display text-lg tracking-wider hidden sm:block">

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -57,16 +57,19 @@ export default function Layout({ children }) {
       <nav className="fixed top-0 left-0 right-0 z-50 bg-deep/90 backdrop-blur-md border-b border-gold-dim/20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            {/* Logo */}
-            <Link to="/" className="flex items-center gap-2.5 text-gold hover:text-gold-light transition-colors">
-              <img src="/icons/talisman-logo.png" alt="" className="w-8 h-8" />
-              <span className="font-display text-lg tracking-wider hidden sm:block">
-                Talisman Tracker
-              </span>
-              <span className="font-display text-lg tracking-wider sm:hidden">
-                TT
-              </span>
-            </Link>
+            {/* Left: group switcher + logo */}
+            <div className="flex items-center gap-3">
+              {user && <span className="hidden md:block"><GroupSwitcher /></span>}
+              <Link to="/" className="flex items-center gap-2.5 text-gold hover:text-gold-light transition-colors">
+                <img src="/icons/talisman-logo.png" alt="" className="w-8 h-8" />
+                <span className="font-display text-lg tracking-wider hidden sm:block">
+                  Talisman Tracker
+                </span>
+                <span className="font-display text-lg tracking-wider sm:hidden">
+                  TT
+                </span>
+              </Link>
+            </div>
 
             {/* Desktop nav */}
             <div className="hidden md:flex items-center gap-6">
@@ -75,7 +78,6 @@ export default function Layout({ children }) {
                   {link.label}
                 </NavLink>
               ))}
-              {user && <GroupSwitcher />}
               {user && (
                 <button
                   onClick={handleSignOut}
@@ -104,6 +106,11 @@ export default function Layout({ children }) {
           }`}
         >
           <div className="px-4 pb-4 pt-1 space-y-1 bg-deep/95 border-t border-gold-dim/10">
+            {user && (
+              <div className="py-2 px-1 border-b border-gold-dim/10 mb-1">
+                <GroupSwitcher onNavigate={() => setMobileOpen(false)} />
+              </div>
+            )}
             {NAV_LINKS.map(link => (
               <NavLink
                 key={link.to}
@@ -121,11 +128,6 @@ export default function Layout({ children }) {
                 {link.label}
               </NavLink>
             ))}
-            {user && (
-              <div className="pt-2 pb-1 px-1">
-                <GroupSwitcher onNavigate={() => setMobileOpen(false)} />
-              </div>
-            )}
             {user && (
               <button
                 onClick={handleSignOut}

--- a/src/components/ScopeToggle.jsx
+++ b/src/components/ScopeToggle.jsx
@@ -1,0 +1,34 @@
+export default function ScopeToggle({ value, onChange, groupName }) {
+  const groupDisabled = !groupName
+
+  return (
+    <div className="inline-flex rounded-lg border border-gold-dim/30 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => value !== 'global' && onChange('global')}
+        className={`px-4 py-1.5 text-sm font-heading transition-colors border-r border-gold-dim/30 ${
+          value === 'global'
+            ? 'bg-gold/20 text-gold'
+            : 'text-parchment/60 hover:text-parchment hover:bg-gold/5'
+        }`}
+      >
+        Global
+      </button>
+      <button
+        type="button"
+        onClick={() => value !== 'group' && onChange('group')}
+        disabled={groupDisabled}
+        title={groupDisabled ? 'Select a group first' : undefined}
+        className={`px-4 py-1.5 text-sm font-heading transition-colors ${
+          value === 'group'
+            ? 'bg-gold/20 text-gold'
+            : groupDisabled
+            ? 'text-parchment/30 cursor-not-allowed'
+            : 'text-parchment/60 hover:text-parchment hover:bg-gold/5'
+        }`}
+      >
+        {groupName ?? 'Group'}
+      </button>
+    </div>
+  )
+}

--- a/src/hooks/useActiveGroup.js
+++ b/src/hooks/useActiveGroup.js
@@ -1,28 +1,54 @@
-import { useState } from 'react'
+import { useSyncExternalStore } from 'react'
 import { useGroups } from './useGroups'
 
 const STORAGE_KEY = 'activeGroupId'
+const CHANGE_EVENT = 'active-group-changed'
 
 function readStored() {
   if (typeof window === 'undefined') return null
   return localStorage.getItem(STORAGE_KEY)
 }
 
+function subscribe(onStoreChange) {
+  if (typeof window === 'undefined') return () => {}
+
+  const handleStorage = (event) => {
+    if (event.key === STORAGE_KEY) onStoreChange()
+  }
+
+  const handleChange = () => onStoreChange()
+
+  window.addEventListener('storage', handleStorage)
+  window.addEventListener(CHANGE_EVENT, handleChange)
+
+  return () => {
+    window.removeEventListener('storage', handleStorage)
+    window.removeEventListener(CHANGE_EVENT, handleChange)
+  }
+}
+
+function writeStored(id) {
+  if (typeof window === 'undefined') return
+
+  if (id) localStorage.setItem(STORAGE_KEY, id)
+  else localStorage.removeItem(STORAGE_KEY)
+
+  window.dispatchEvent(new Event(CHANGE_EVENT))
+}
+
 export function useActiveGroup() {
   const { data: groups = [], isLoading } = useGroups()
-  const [storedId, setStoredId] = useState(readStored)
+  const storedId = useSyncExternalStore(subscribe, readStored, () => null)
 
-  // If groups have loaded and the stored id isn't one of them, treat as null.
-  // The stale value can stay in localStorage — it gets overwritten on next pick,
+  // If groups have loaded and the stored id is not one of them, treat as null.
+  // The stale value can stay in localStorage - it gets overwritten on next pick,
   // and this derivation filters it out on read.
   const isStale = !isLoading && storedId && !groups.find((g) => g.id === storedId)
   const activeGroupId = isStale ? null : storedId
   const activeGroup = groups.find((g) => g.id === activeGroupId) ?? null
 
   const setActiveGroup = (id) => {
-    setStoredId(id)
-    if (id) localStorage.setItem(STORAGE_KEY, id)
-    else localStorage.removeItem(STORAGE_KEY)
+    writeStored(id)
   }
 
   return { activeGroupId, activeGroup, groups, setActiveGroup, isLoading }

--- a/src/hooks/useEncounterScores.js
+++ b/src/hooks/useEncounterScores.js
@@ -1,14 +1,18 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 
-export function useEncounterScores() {
+export function useEncounterScores(groupId) {
   return useQuery({
-    queryKey: ['encounterScores'],
+    queryKey: ['encounterScores', groupId ?? 'global'],
     queryFn: async () => {
-      const { data, error } = await supabase
+      let query = supabase
         .from('encounter_scores')
         .select('id, encounter_name, creature_wins, player_wins')
         .order('encounter_name')
+
+      if (groupId) query = query.eq('group_id', groupId)
+
+      const { data, error } = await query
       if (error) throw error
       return (data ?? []).map((row) => ({
         id: row.id,

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -20,31 +20,55 @@ const DERIVED_CATEGORIES = {
   most_toad_times: 'total_toad_times',
 }
 
-export function useHighscoreRecords() {
+export function useHighscoreRecords(groupId) {
   return useQuery({
-    queryKey: ['highscoreRecords'],
+    queryKey: ['highscoreRecords', groupId ?? 'global'],
     queryFn: async () => {
-      const [hsResult, gpResult, deathResult] = await Promise.all([
-        supabase
-          .from('game_highscores')
-          .select(`
-            category,
-            value,
-            player:players ( id, name ),
-            game:games ( id, date )
-          `),
-        supabase
-          .from('game_players')
-          .select(`
-            game_id,
-            total_toad_times,
-            player:players ( id, name ),
-            game:games ( id, date )
-          `),
-        supabase
-          .from('game_player_deaths')
-          .select('game_id, player_id'),
-      ])
+      let gameIds = null
+
+      if (groupId) {
+        const { data: gamesData, error: gamesError } = await supabase
+          .from('games')
+          .select('id')
+          .eq('group_id', groupId)
+        if (gamesError) throw gamesError
+        gameIds = gamesData.map(g => g.id)
+        if (gameIds.length === 0) return Object.keys(CATEGORY_LABELS).map((category) => ({
+          category,
+          label: CATEGORY_LABELS[category],
+          entries: [],
+        }))
+      }
+
+      let hsQuery = supabase
+        .from('game_highscores')
+        .select(`
+          category,
+          value,
+          player:players ( id, name ),
+          game:games ( id, date )
+        `)
+
+      let gpQuery = supabase
+        .from('game_players')
+        .select(`
+          game_id,
+          total_toad_times,
+          player:players ( id, name ),
+          game:games ( id, date )
+        `)
+
+      let deathQuery = supabase
+        .from('game_player_deaths')
+        .select('game_id, player_id')
+
+      if (gameIds) {
+        hsQuery = hsQuery.in('game_id', gameIds)
+        gpQuery = gpQuery.in('game_id', gameIds)
+        deathQuery = deathQuery.in('game_id', gameIds)
+      }
+
+      const [hsResult, gpResult, deathResult] = await Promise.all([hsQuery, gpQuery, deathQuery])
 
       if (hsResult.error) throw hsResult.error
       if (gpResult.error) throw gpResult.error
@@ -56,7 +80,7 @@ export function useHighscoreRecords() {
         deathCounts.set(key, (deathCounts.get(key) ?? 0) + 1)
       }
 
-      gpResult.data = gpResult.data.map(gp => ({
+      const gpWithDeaths = gpResult.data.map(gp => ({
         ...gp,
         total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
       }))
@@ -69,7 +93,7 @@ export function useHighscoreRecords() {
 
       for (const [category, column] of Object.entries(DERIVED_CATEGORIES)) {
         const rows = []
-        for (const gp of gpResult.data) {
+        for (const gp of gpWithDeaths) {
           const value = Number(gp[column] ?? 0)
           if (value <= 0) continue
           rows.push({ category, value, player: gp.player, game: gp.game })

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -2,26 +2,44 @@ import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 import { computeLeaderboard } from '../lib/statsHelpers'
 
-export function useLeaderboardStats() {
+export function useLeaderboardStats(groupId) {
   return useQuery({
-    queryKey: ['leaderboardStats'],
+    queryKey: ['leaderboardStats', groupId ?? 'global'],
     queryFn: async () => {
-      const [gpResult, deathResult] = await Promise.all([
-        supabase
-          .from('game_players')
-          .select(`
-            game_id,
-            characters_played,
-            total_toad_times,
-            is_winner,
-            winning_character,
-            player:players ( id, name ),
-            game:games ( id, created_at )
-          `),
-        supabase
-          .from('game_player_deaths')
-          .select('game_id, player_id, killed_by_player_id, death_type:death_types(name)'),
-      ])
+      let gameIds = null
+
+      if (groupId) {
+        const { data: gamesData, error: gamesError } = await supabase
+          .from('games')
+          .select('id')
+          .eq('group_id', groupId)
+        if (gamesError) throw gamesError
+        gameIds = gamesData.map(g => g.id)
+        if (gameIds.length === 0) return []
+      }
+
+      let gpQuery = supabase
+        .from('game_players')
+        .select(`
+          game_id,
+          characters_played,
+          total_toad_times,
+          is_winner,
+          winning_character,
+          player:players ( id, name ),
+          game:games ( id, created_at )
+        `)
+
+      let deathQuery = supabase
+        .from('game_player_deaths')
+        .select('game_id, player_id, killed_by_player_id, death_type:death_types(name)')
+
+      if (gameIds) {
+        gpQuery = gpQuery.in('game_id', gameIds)
+        deathQuery = deathQuery.in('game_id', gameIds)
+      }
+
+      const [gpResult, deathResult] = await Promise.all([gpQuery, deathQuery])
       if (gpResult.error) throw gpResult.error
       if (deathResult.error) throw deathResult.error
 

--- a/src/hooks/useStatsData.js
+++ b/src/hooks/useStatsData.js
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 
-export function useStatsData() {
+export function useStatsData(groupId) {
   return useQuery({
-    queryKey: ['stats'],
+    queryKey: ['stats', groupId ?? 'global'],
     queryFn: async () => {
-      const { data, error } = await supabase
+      let query = supabase
         .from('games')
         .select(`
           id,
@@ -35,6 +35,10 @@ export function useStatsData() {
             killed_by:players!game_player_deaths_killed_by_fkey ( id, name )
           )
         `)
+
+      if (groupId) query = query.eq('group_id', groupId)
+
+      const { data, error } = await query
       if (error) throw error
       return (data ?? []).map(game => {
         const allDeaths = game.deaths ?? []

--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react'
 import { useEncounterScores } from '../hooks/useEncounterScores'
 import { useUpdateEncounterScore } from '../hooks/useUpdateEncounterScore'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import ScopeToggle from '../components/ScopeToggle'
 
 const ENCOUNTERS = [
   {
@@ -90,7 +93,15 @@ function EncounterCard({ encounter, score, onUpdate, isPending }) {
 }
 
 export default function Counters() {
-  const { data: scores = [], error, isLoading } = useEncounterScores()
+  const { activeGroupId, activeGroup } = useActiveGroup()
+  const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
+
+  useEffect(() => {
+    setScope(activeGroupId ? 'group' : 'global')
+  }, [activeGroupId])
+
+  const groupId = scope === 'group' ? activeGroupId : null
+  const { data: scores = [], error, isLoading } = useEncounterScores(groupId)
   const mutation = useUpdateEncounterScore()
 
   const handleUpdate = (encounterName, column, delta) => {
@@ -105,6 +116,9 @@ export default function Counters() {
         <h1 className="font-heading text-3xl text-parchment tracking-wide">Encounter Counters</h1>
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
+        </div>
+        <div className="mt-3 flex justify-center">
+          <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
         </div>
         <p className="text-muted text-sm font-body mt-3">
           Running scoreboards for creature encounters.

--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -97,6 +97,7 @@ export default function Counters() {
   const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setScope(activeGroupId ? 'group' : 'global')
   }, [activeGroupId])
 

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -83,6 +83,7 @@ export default function HighscoresBoard() {
   const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setScope(activeGroupId ? 'group' : 'global')
   }, [activeGroupId])
 

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useHighscoreRecords } from '../hooks/useHighscoreRecords'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import ScopeToggle from '../components/ScopeToggle'
 
 const CATEGORY_ICONS = {
   most_gold: (
@@ -76,7 +79,15 @@ const CATEGORY_ICONS = {
 }
 
 export default function HighscoresBoard() {
-  const { data: records = [], error } = useHighscoreRecords()
+  const { activeGroupId, activeGroup } = useActiveGroup()
+  const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
+
+  useEffect(() => {
+    setScope(activeGroupId ? 'group' : 'global')
+  }, [activeGroupId])
+
+  const groupId = scope === 'group' ? activeGroupId : null
+  const { data: records = [], isLoading, error } = useHighscoreRecords(groupId)
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-8 animate-fade-up text-center">
@@ -84,68 +95,77 @@ export default function HighscoresBoard() {
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
         </div>
-        <p className="text-muted text-sm font-body mt-3">All-time per-game records across all sessions.</p>
+        <div className="mt-3 flex justify-center">
+          <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
+        </div>
+        <p className="text-muted text-sm font-body mt-3">
+          {scope === 'group' ? 'Per-game records within this group.' : 'All-time per-game records across all sessions.'}
+        </p>
       </div>
 
       {error && (
         <p className="text-danger text-sm font-body mb-4">{error.message}</p>
       )}
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {records.map((record, i) => {
-          const empty = record.entries.length === 0
-          const [gold] = record.entries
-          return (
-            <div
-              key={record.category}
-              className={`card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 animate-fade-up delay-${i + 2}`}
-            >
-              <div className="flex items-center justify-between mb-3 gap-3">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="text-gold/50 shrink-0">{CATEGORY_ICONS[record.category]}</div>
-                  <h3 className="font-heading text-parchment text-xl tracking-wide truncate">{record.label}</h3>
+      {isLoading ? (
+        <p className="text-muted text-sm font-body italic text-center">Loading...</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {records.map((record, i) => {
+            const empty = record.entries.length === 0
+            const [gold] = record.entries
+            return (
+              <div
+                key={record.category}
+                className={`card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 animate-fade-up delay-${i + 2}`}
+              >
+                <div className="flex items-center justify-between mb-3 gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="text-gold/50 shrink-0">{CATEGORY_ICONS[record.category]}</div>
+                    <h3 className="font-heading text-parchment text-xl tracking-wide truncate">{record.label}</h3>
+                  </div>
+                  <span className={`font-display text-3xl tracking-wider leading-none shrink-0 ${empty ? 'text-muted/40' : 'text-gold'}`}>
+                    {empty ? '×' : gold.value}
+                  </span>
                 </div>
-                <span className={`font-display text-3xl tracking-wider leading-none shrink-0 ${empty ? 'text-muted/40' : 'text-gold'}`}>
-                  {empty ? '×' : gold.value}
-                </span>
-              </div>
-              {empty && <p className="text-muted text-sm font-body mb-3">No record yet</p>}
+                {empty && <p className="text-muted text-sm font-body mb-3">No record yet</p>}
 
-              {!empty && (
-                <div className="border-t border-gold-dim/10 pt-3">
-                  <ol className="space-y-1.5">
-                    {record.entries.map((entry, idx) => (
-                      <li key={entry.rank} className={`flex items-center justify-between text-sm font-body px-2 py-1 rounded ${idx % 2 === 0 ? 'bg-gold/[0.04]' : ''}`}>
-                        <div className="flex items-center gap-2 min-w-0">
-                          <span className={`w-4 shrink-0 text-right font-display ${entry.rank === 1 ? 'text-gold' : 'text-muted/60'}`}>
-                            {entry.rank}
-                          </span>
-                          <span className={`truncate ${entry.rank === 1 ? 'text-gold/90' : 'text-parchment/70'}`}>
-                            {entry.player ?? 'Talisman'}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-3 shrink-0 ml-2">
-                          <span className={`font-display ${entry.rank === 1 ? 'text-parchment' : 'text-muted'}`}>
-                            {entry.value}
-                          </span>
-                          {entry.game_id && (
-                            <Link
-                              to={`/games/${entry.game_id}`}
-                              className="text-muted/50 hover:text-teal-light transition-colors text-xs"
-                            >
-                              {new Date(entry.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                            </Link>
-                          )}
-                        </div>
-                      </li>
-                    ))}
-                  </ol>
-                </div>
-              )}
-            </div>
-          )
-        })}
-      </div>
+                {!empty && (
+                  <div className="border-t border-gold-dim/10 pt-3">
+                    <ol className="space-y-1.5">
+                      {record.entries.map((entry, idx) => (
+                        <li key={entry.rank} className={`flex items-center justify-between text-sm font-body px-2 py-1 rounded ${idx % 2 === 0 ? 'bg-gold/[0.04]' : ''}`}>
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className={`w-4 shrink-0 text-right font-display ${entry.rank === 1 ? 'text-gold' : 'text-muted/60'}`}>
+                              {entry.rank}
+                            </span>
+                            <span className={`truncate ${entry.rank === 1 ? 'text-gold/90' : 'text-parchment/70'}`}>
+                              {entry.player ?? 'Talisman'}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-3 shrink-0 ml-2">
+                            <span className={`font-display ${entry.rank === 1 ? 'text-parchment' : 'text-muted'}`}>
+                              {entry.value}
+                            </span>
+                            {entry.game_id && (
+                              <Link
+                                to={`/games/${entry.game_id}`}
+                                className="text-muted/50 hover:text-teal-light transition-colors text-xs"
+                              >
+                                {new Date(entry.game_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                              </Link>
+                            )}
+                          </div>
+                        </li>
+                      ))}
+                    </ol>
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
 
       {/* Empty state hint */}
       <div className="mt-12 text-center">

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useLeaderboardStats } from '../hooks/useLeaderboardStats'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import ScopeToggle from '../components/ScopeToggle'
 
 const TALISMAN_SHOW = new Set(['name', 'games_played', 'wins', 'win_rate'])
 
@@ -31,9 +33,17 @@ function SortIcon({ active, direction }) {
 }
 
 export default function Leaderboard() {
+  const { activeGroupId, activeGroup } = useActiveGroup()
+  const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
   const [sortKey, setSortKey] = useState('wins')
   const [sortDir, setSortDir] = useState('desc')
-  const { data: rows = [], error } = useLeaderboardStats()
+
+  useEffect(() => {
+    setScope(activeGroupId ? 'group' : 'global')
+  }, [activeGroupId])
+
+  const groupId = scope === 'group' ? activeGroupId : null
+  const { data: rows = [], error, isLoading } = useLeaderboardStats(groupId)
 
   const sorted = [...rows].sort((a, b) => {
     const aVal = a[sortKey]
@@ -58,14 +68,17 @@ export default function Leaderboard() {
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
         </div>
-        <p className="text-muted text-sm font-body mt-3">Across all logged games. Click any column to sort.</p>
+        <div className="mt-3 flex justify-center">
+          <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
+        </div>
+        <p className="text-muted text-sm font-body mt-3">Click any column to sort.</p>
       </div>
 
       {error && (
         <p className="text-danger text-sm font-body mb-4">{error.message}</p>
       )}
 
-      {rows.length === 0 ? (
+      {!isLoading && rows.length === 0 ? (
         <p className="text-muted text-sm font-body italic text-center">No stats yet. Log a game to populate the leaderboard.</p>
       ) : (
       <>

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -39,6 +39,7 @@ export default function Leaderboard() {
   const [sortDir, setSortDir] = useState('desc')
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setScope(activeGroupId ? 'group' : 'global')
   }, [activeGroupId])
 

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { WoodlandPathTooltip } from '../components/WoodlandPathTooltip'
 import { useStatsData } from '../hooks/useStatsData'
 import { useCharacters } from '../hooks/useCharacters'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import ScopeToggle from '../components/ScopeToggle'
 import {
   OPTIONAL_EXPANSION_FILTERS,
   filterGamesByOptionalExpansions,
@@ -604,7 +606,19 @@ function DeathsTab({ games }) {
 export default function Stats() {
   const [tab, setTab] = useState('characters')
   const [optionalFilter, setOptionalFilter] = useState('all')
-  const { data: rawGames = [], error, isLoading } = useStatsData()
+  const { activeGroupId, activeGroup } = useActiveGroup()
+  const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
+
+  useEffect(() => {
+    setScope(activeGroupId ? 'group' : 'global')
+  }, [activeGroupId])
+
+  useEffect(() => {
+    setOptionalFilter('all')
+  }, [scope])
+
+  const groupId = scope === 'group' ? activeGroupId : null
+  const { data: rawGames = [], error, isLoading } = useStatsData(groupId)
   const { data: allCharacters = [] } = useCharacters()
 
   const games = useMemo(
@@ -619,8 +633,11 @@ export default function Stats() {
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
         </div>
+        <div className="mt-3 flex justify-center">
+          <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
+        </div>
         <p className="text-muted text-sm font-body mt-3">
-          Global breakdown of characters, endings, and expansion events.
+          {scope === 'group' ? 'Group breakdown of characters, endings, and expansion events.' : 'Global breakdown of characters, endings, and expansion events.'}
         </p>
       </div>
 

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -610,10 +610,12 @@ export default function Stats() {
   const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setScope(activeGroupId ? 'group' : 'global')
   }, [activeGroupId])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setOptionalFilter('all')
   }, [scope])
 


### PR DESCRIPTION
## Summary
- fix active-group syncing by replacing component-local state in useActiveGroup with a shared external store subscription
- emit a same-tab active-group-changed event when switching groups and subscribe to both custom and storage events
- keep stale stored group-id filtering behavior intact

## Root Cause
useActiveGroup used useState(readStored) per component instance. The top-left GroupSwitcher updated only its own hook instance, while Stats/Leaderboard/Highscores had separate stale hook state and did not react immediately.

## Validation
- npx eslint src/hooks/useActiveGroup.js
- npm run build

## Notes
- Full npm run lint currently fails on pre-existing unrelated react-hooks/set-state-in-effect errors in src/components/WoodlandPathTooltip.jsx and src/pages/Tierlist.jsx.
- Fixes #84.