### PR TITLE
[codex] Scope games to active group and fix Home performance/count mismatch

### DIFF
--- a/src/components/GroupRequiredState.jsx
+++ b/src/components/GroupRequiredState.jsx
@@ -1,0 +1,26 @@
+import { Link } from 'react-router-dom'
+
+export default function GroupRequiredState({
+  title = 'Select a group first',
+  body = 'Games are scoped to a specific group. Choose an active group or create one to continue.',
+}) {
+  return (
+    <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 sm:p-8 text-center animate-fade-up">
+        <h1 className="font-heading text-2xl text-parchment tracking-wide">{title}</h1>
+        <div className="ornament-divider mt-3">
+          <span className="text-gold-dim">&#9670;</span>
+        </div>
+        <p className="text-muted font-body mt-4 max-w-xl mx-auto">{body}</p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <Link to="/groups" className="btn-outline text-sm">
+            Browse Groups
+          </Link>
+          <Link to="/groups/new" className="btn-gold text-sm">
+            Create Group
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/useDeleteGame.js
+++ b/src/hooks/useDeleteGame.js
@@ -1,18 +1,33 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { useActiveGroup } from './useActiveGroup'
 
 export function useDeleteGame() {
   const queryClient = useQueryClient()
+  const { activeGroupId } = useActiveGroup()
+
   return useMutation({
     mutationFn: async (gameId) => {
-      const { error } = await supabase.from('games').delete().eq('id', gameId)
+      if (!activeGroupId) {
+        throw new Error('Select an active group before deleting a game.')
+      }
+
+      const { data, error } = await supabase
+        .from('games')
+        .delete()
+        .eq('group_id', activeGroupId)
+        .eq('id', gameId)
+        .select('id')
+        .maybeSingle()
       if (error) throw error
+      if (!data) throw new Error('Game not found in the active group.')
       return gameId
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['games'] })
       queryClient.invalidateQueries({ queryKey: ['leaderboardStats'] })
       queryClient.invalidateQueries({ queryKey: ['highscoreRecords'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
     },
   })
 }

--- a/src/hooks/useGame.js
+++ b/src/hooks/useGame.js
@@ -1,11 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { useActiveGroup } from './useActiveGroup'
 
 export function useGame(id) {
+  const { activeGroupId, isLoading: groupsLoading } = useActiveGroup()
+
   return useQuery({
-    queryKey: ['game', id],
-    enabled: !!id,
+    queryKey: ['game', id, activeGroupId ?? 'none'],
+    enabled: !!id && !groupsLoading,
     queryFn: async () => {
+      if (!activeGroupId) return null
+
       const { data, error } = await supabase
         .from('games')
         .select(`
@@ -49,8 +54,10 @@ export function useGame(id) {
           )
         `)
         .eq('id', id)
-        .single()
+        .eq('group_id', activeGroupId)
+        .maybeSingle()
       if (error) throw error
+      if (!data) return null
       const allDeaths = data.deaths ?? []
       return {
         id: data.id,

--- a/src/hooks/useGames.js
+++ b/src/hooks/useGames.js
@@ -2,16 +2,18 @@ import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 import { useActiveGroup } from './useActiveGroup'
 
-export function useGames() {
+export function useGames(groupIdOverride) {
   const { activeGroupId, isLoading: groupsLoading } = useActiveGroup()
+  const resolvedGroupId = groupIdOverride === undefined ? activeGroupId : groupIdOverride
+  const explicitScope = groupIdOverride !== undefined
 
   return useQuery({
-    queryKey: ['games', activeGroupId ?? 'none'],
-    enabled: !groupsLoading,
+    queryKey: ['games', resolvedGroupId === null ? 'global' : resolvedGroupId ?? 'none'],
+    enabled: explicitScope || !groupsLoading,
     queryFn: async () => {
-      if (!activeGroupId) return []
+      if (!explicitScope && !resolvedGroupId) return []
 
-      const { data, error } = await supabase
+      let query = supabase
         .from('games')
         .select(`
           id,
@@ -30,8 +32,13 @@ export function useGames() {
           ),
           expansion_events:game_expansion_events ( id )
         `)
-        .eq('group_id', activeGroupId)
         .order('date', { ascending: false })
+
+      if (resolvedGroupId) {
+        query = query.eq('group_id', resolvedGroupId)
+      }
+
+      const { data, error } = await query
       if (error) throw error
       return data.map((g) => ({
         id: g.id,

--- a/src/hooks/useGames.js
+++ b/src/hooks/useGames.js
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { useActiveGroup } from './useActiveGroup'
 
 export function useGames() {
+  const { activeGroupId, isLoading: groupsLoading } = useActiveGroup()
+
   return useQuery({
-    queryKey: ['games'],
+    queryKey: ['games', activeGroupId ?? 'none'],
+    enabled: !groupsLoading,
     queryFn: async () => {
+      if (!activeGroupId) return []
+
       const { data, error } = await supabase
         .from('games')
         .select(`
@@ -24,6 +30,7 @@ export function useGames() {
           ),
           expansion_events:game_expansion_events ( id )
         `)
+        .eq('group_id', activeGroupId)
         .order('date', { ascending: false })
       if (error) throw error
       return data.map((g) => ({

--- a/src/hooks/useLogGame.js
+++ b/src/hooks/useLogGame.js
@@ -1,17 +1,25 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 import { insertChildRows } from '../lib/gameWrites'
+import { useActiveGroup } from './useActiveGroup'
 
 export function useLogGame() {
   const queryClient = useQueryClient()
+  const { activeGroupId } = useActiveGroup()
+
   return useMutation({
     mutationFn: async (formState) => {
+      if (!activeGroupId) {
+        throw new Error('Select an active group before logging a game.')
+      }
+
       const { data: game, error: gErr } = await supabase
         .from('games')
         .insert({
           title: formState.title.trim(),
           date: formState.date,
           ending_id: formState.ending_id,
+          group_id: activeGroupId,
           notes: formState.notes || null,
           optional_expansions: formState.optional_expansions ?? [],
         })

--- a/src/hooks/useUpdateGame.js
+++ b/src/hooks/useUpdateGame.js
@@ -1,12 +1,19 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 import { deleteChildRows, insertChildRows } from '../lib/gameWrites'
+import { useActiveGroup } from './useActiveGroup'
 
 export function useUpdateGame() {
   const queryClient = useQueryClient()
+  const { activeGroupId } = useActiveGroup()
+
   return useMutation({
     mutationFn: async ({ gameId, formState }) => {
-      const { error: gErr } = await supabase
+      if (!activeGroupId) {
+        throw new Error('Select an active group before editing a game.')
+      }
+
+      const { data: updatedGame, error: gErr } = await supabase
         .from('games')
         .update({
           title: formState.title.trim(),
@@ -16,8 +23,12 @@ export function useUpdateGame() {
           optional_expansions: formState.optional_expansions ?? [],
           updated_at: new Date().toISOString(),
         })
+        .eq('group_id', activeGroupId)
         .eq('id', gameId)
+        .select('id')
+        .maybeSingle()
       if (gErr) throw gErr
+      if (!updatedGame) throw new Error('Game not found in the active group.')
 
       await deleteChildRows(gameId)
       await insertChildRows(gameId, formState)

--- a/src/index.css
+++ b/src/index.css
@@ -299,22 +299,20 @@ body::before {
 .hero-ring-spin {
   transform-box: view-box;
   transform-origin: 200px 200px;
-  animation: ringSpin 180s linear infinite;
+  animation: none;
 }
 .hero-ring-spin-reverse {
   transform-box: view-box;
   transform-origin: 200px 200px;
-  animation: ringSpinReverse 240s linear infinite;
+  animation: none;
 }
 
 @keyframes medallionBreathe {
   0%, 100% {
-    opacity: 0.4;
-    filter: drop-shadow(0 0 18px rgba(201, 168, 76, 0.12));
+    opacity: 0.42;
   }
   50% {
-    opacity: 0.55;
-    filter: drop-shadow(0 0 32px rgba(201, 168, 76, 0.28));
+    opacity: 0.5;
   }
 }
 .hero-medallion-svg {
@@ -331,15 +329,26 @@ body::before {
 .board-spin-slow {
   transform-box: view-box;
   transform-origin: 400px 400px;
-  animation: boardSpinSlow 300s linear infinite;
+  animation: none;
 }
 .board-spin-rev {
   transform-box: view-box;
   transform-origin: 400px 400px;
-  animation: boardSpinRev 220s linear infinite;
+  animation: none;
 }
 .hero-board-svg {
-  animation: medallionBreathe 9s ease-in-out infinite;
+  opacity: 0.92;
+}
+
+@media (prefers-reduced-motion: reduce), (update: slow) {
+  .hero-ring-spin,
+  .hero-ring-spin-reverse,
+  .hero-medallion-svg,
+  .board-spin-slow,
+  .board-spin-rev,
+  .animate-glow {
+    animation: none !important;
+  }
 }
 
 /* Heraldic portrait frame (player avatars, lg variant) */

--- a/src/pages/EditGame.jsx
+++ b/src/pages/EditGame.jsx
@@ -1,9 +1,12 @@
 import { useParams } from 'react-router-dom'
 import { useGame } from '../hooks/useGame'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import GroupRequiredState from '../components/GroupRequiredState'
 import LogGame from './LogGame'
 
 export default function EditGame() {
   const { id } = useParams()
+  const { activeGroupId, isLoading: groupsLoading } = useActiveGroup()
   const { data: game, error, isLoading } = useGame(id)
 
   if (error) {
@@ -13,7 +16,31 @@ export default function EditGame() {
       </div>
     )
   }
-  if (isLoading || !game) return null
+  if (groupsLoading || isLoading) return null
+
+  if (!activeGroupId) {
+    return (
+      <GroupRequiredState
+        title="Select a group to edit games"
+        body="Games are scoped to the active group. Pick the group that owns this game before editing it."
+      />
+    )
+  }
+  if (!game) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 text-center animate-fade-up">
+          <h1 className="font-heading text-2xl text-parchment tracking-wide">Game not found</h1>
+          <div className="ornament-divider mt-3">
+            <span className="text-gold-dim">&#9670;</span>
+          </div>
+          <p className="text-muted font-body mt-4">
+            This game is not in the active group, or it no longer exists.
+          </p>
+        </div>
+      </div>
+    )
+  }
 
   const initialData = {
     title: game.title ?? '',

--- a/src/pages/GameDetail.jsx
+++ b/src/pages/GameDetail.jsx
@@ -1,6 +1,8 @@
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useGame } from '../hooks/useGame'
 import { useDeleteGame } from '../hooks/useDeleteGame'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import GroupRequiredState from '../components/GroupRequiredState'
 import { WoodlandPathTooltip } from '../components/WoodlandPathTooltip'
 
 function formatDate(dateStr) {
@@ -45,7 +47,8 @@ function groupEventsByPlayer(events) {
 export default function GameDetail() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const { data: game, error } = useGame(id)
+  const { activeGroupId, isLoading: groupsLoading } = useActiveGroup()
+  const { data: game, error, isLoading } = useGame(id)
   const deleteGame = useDeleteGame()
 
   const handleDelete = () => {
@@ -62,7 +65,36 @@ export default function GameDetail() {
       </div>
     )
   }
-  if (!game) return null
+  if (groupsLoading || isLoading) return null
+
+  if (!activeGroupId) {
+    return (
+      <GroupRequiredState
+        title="Select a group to view game details"
+        body="Game details are scoped to the active group. Pick the group that owns this session to continue."
+      />
+    )
+  }
+  if (!game) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 text-center animate-fade-up">
+          <h1 className="font-heading text-2xl text-parchment tracking-wide">Game not found</h1>
+          <div className="ornament-divider mt-3">
+            <span className="text-gold-dim">&#9670;</span>
+          </div>
+          <p className="text-muted font-body mt-4">
+            This game is not in the active group, or it no longer exists.
+          </p>
+          <div className="mt-6 flex justify-center">
+            <Link to="/history" className="btn-outline text-sm">
+              Back to History
+            </Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   const winners = game.players.filter(p => p.is_winner)
 

--- a/src/pages/GameHistory.jsx
+++ b/src/pages/GameHistory.jsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom'
 import { useGames } from '../hooks/useGames'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import GroupRequiredState from '../components/GroupRequiredState'
 
 function formatDate(dateStr) {
   return new Date(dateStr).toLocaleDateString('en-US', {
@@ -11,7 +13,19 @@ function formatDate(dateStr) {
 }
 
 export default function GameHistory() {
-  const { data: games = [], error } = useGames()
+  const { activeGroupId, activeGroup, isLoading: groupsLoading } = useActiveGroup()
+  const { data: games = [], error, isLoading } = useGames()
+
+  if (groupsLoading || isLoading) return null
+
+  if (!activeGroupId) {
+    return (
+      <GroupRequiredState
+        title="Select a group to view game history"
+        body="Game history is now scoped to the active group. Pick a group to browse its sessions."
+      />
+    )
+  }
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -25,7 +39,9 @@ export default function GameHistory() {
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
         </div>
-        <p className="text-muted text-sm font-body mt-3">{games.length} games chronicled</p>
+        <p className="text-muted text-sm font-body mt-3">
+          {activeGroup ? `${activeGroup.name}: ` : ''}{games.length} games chronicled
+        </p>
       </div>
 
       {error && (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -48,7 +48,7 @@ function BoardBackdrop() {
   return (
     <svg
       viewBox="0 0 800 800"
-      className="hero-board-svg w-[min(140vw,1200px)] h-auto"
+      className="hero-board-svg w-[min(120vw,960px)] h-auto"
       aria-hidden
     >
       <defs>
@@ -308,7 +308,7 @@ const QUICK_LINKS = [
 ]
 
 export default function Home() {
-  const { data: games = [] } = useGames()
+  const { data: games = [] } = useGames(null)
   const { data: stats = [] } = useLeaderboardStats()
   const gameCount = games.length
   const championCount = stats.filter(s => s.wins > 0).length

--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -8,8 +8,10 @@ import { useLogGame } from '../hooks/useLogGame'
 import { useUpdateGame } from '../hooks/useUpdateGame'
 import { useDeleteGame } from '../hooks/useDeleteGame'
 import { useDeathTypes } from '../hooks/useDeathTypes'
+import { useActiveGroup } from '../hooks/useActiveGroup'
 import { AVAILABLE_ICONS } from '../data/availableIcons'
 import { WOODLAND_PATHS } from '../data/woodlandPaths'
+import GroupRequiredState from '../components/GroupRequiredState'
 import { WoodlandPathTooltip } from '../components/WoodlandPathTooltip'
 
 const charIconUrl = (name) => {
@@ -100,6 +102,7 @@ export default function LogGame({ initialData, isEditing, gameId }) {
   const [form, setForm] = useState(initialData || INITIAL_STATE)
   const [showAddPlayer, setShowAddPlayer] = useState(false)
   const [newPlayerName, setNewPlayerName] = useState('')
+  const { activeGroupId, activeGroup, isLoading: groupsLoading } = useActiveGroup()
 
   const { data: allPlayers = [] } = usePlayers()
   const { data: allCharacters = [] } = useCharacters()
@@ -109,6 +112,21 @@ export default function LogGame({ initialData, isEditing, gameId }) {
   const logGame = useLogGame()
   const updateGame = useUpdateGame()
   const deleteGame = useDeleteGame()
+
+  if (groupsLoading) return null
+
+  if (!activeGroupId) {
+    return (
+      <GroupRequiredState
+        title={isEditing ? 'Select a group to edit games' : 'Select a group to log games'}
+        body={
+          isEditing
+            ? 'Games belong to a specific group. Pick the active group that owns this game before editing it.'
+            : 'Every game now belongs to a specific group. Choose an active group before logging a new game.'
+        }
+      />
+    )
+  }
 
   const updateForm = (key, value) => setForm(prev => ({ ...prev, [key]: value }))
 
@@ -479,6 +497,11 @@ export default function LogGame({ initialData, isEditing, gameId }) {
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
         </div>
+        {activeGroup && (
+          <p className="text-muted text-sm font-body mt-3">
+            Group: {activeGroup.name}
+          </p>
+        )}
       </div>
 
       <StepIndicator step={step} />

--- a/supabase/migrations/20260422123000_games_group_id_not_null.sql
+++ b/supabase/migrations/20260422123000_games_group_id_not_null.sql
@@ -1,0 +1,10 @@
+do $$
+begin
+  if exists (select 1 from games where group_id is null) then
+    raise exception 'games.group_id still contains null rows; backfill before applying this migration';
+  end if;
+end;
+$$;
+
+alter table games
+alter column group_id set not null;


### PR DESCRIPTION
## Summary
This PR delivers the core #73 game scoping changes and one additional Home-page bugfix.

### Games group scoping
- Added migration to enforce non-null `games.group_id` after backfill
- Scoped game CRUD to the active group
- Scoped game reads (`useGames`, `useGame`) to the active group
- Added explicit group-required/not-found UX states for Log/History/Detail/Edit

### Home bugfix
- Removed rotating hero motion that caused lag on some machines
- Home teaser game count now uses global game scope so it matches global champion count

## Validation
- npx eslint src/components/GroupRequiredState.jsx src/hooks/useGames.js src/hooks/useGame.js src/hooks/useLogGame.js src/hooks/useUpdateGame.js src/hooks/useDeleteGame.js src/pages/LogGame.jsx src/pages/GameHistory.jsx src/pages/GameDetail.jsx src/pages/EditGame.jsx
- npx eslint src/hooks/useGames.js src/pages/Home.jsx
- npm run build
- npx supabase db push

## Note
- Full-repo `npm run lint` still reports pre-existing `react-hooks/set-state-in-effect` findings in `WoodlandPathTooltip.jsx` and `Tierlist.jsx` (not introduced here).
