### PR TITLE
[codex] Scope encounter counters by group

### DIFF
--- a/src/components/GroupSwitcher.jsx
+++ b/src/components/GroupSwitcher.jsx
@@ -1,14 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useActiveGroup } from '../hooks/useActiveGroup'
 import { useAuth } from '../hooks/useAuth'
 import { useGroupJoinRequests } from '../hooks/useJoinRequests'
+import { getGroupSwitchDestination } from '../lib/groupNavigation'
 
 export default function GroupSwitcher({ onNavigate }) {
   const { activeGroup, groups, setActiveGroup } = useActiveGroup()
   const { user } = useAuth()
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
+  const location = useLocation()
   const containerRef = useRef(null)
 
   useEffect(() => {
@@ -30,9 +32,21 @@ export default function GroupSwitcher({ onNavigate }) {
   const pendingCount = pendingRequests.length
 
   const choose = (id) => {
+    const nextGroup = groups.find((g) => g.id === id)
+    const destination = getGroupSwitchDestination({
+      currentPathname: location.pathname,
+      nextGroupId: nextGroup?.id ?? null,
+      nextGroupAdminUserId: nextGroup?.admin_user_id ?? null,
+      userId: user?.id ?? null,
+    })
+
     setActiveGroup(id)
     setOpen(false)
     onNavigate?.()
+
+    if (destination) {
+      navigate(destination)
+    }
   }
 
   const goCreate = () => {

--- a/src/components/WoodlandPathTooltip.jsx
+++ b/src/components/WoodlandPathTooltip.jsx
@@ -8,7 +8,6 @@ const MARGIN = 8
 
 export function WoodlandPathTooltip({ name, children }) {
   const [anchor, setAnchor] = useState(null)
-  const [pos, setPos] = useState(null)
   const tooltipRef = useRef(null)
   const data = WOODLAND_PATHS.find(p => p.name === name)
 
@@ -26,7 +25,9 @@ export function WoodlandPathTooltip({ name, children }) {
     if (top < MARGIN) top = anchor.bottom + GAP
     if (top + tipH + MARGIN > vh) top = Math.max(MARGIN, vh - tipH - MARGIN)
 
-    setPos({ left, top })
+    tooltipRef.current.style.left = `${left}px`
+    tooltipRef.current.style.top = `${top}px`
+    tooltipRef.current.style.visibility = 'visible'
   }, [anchor])
 
   return (
@@ -36,7 +37,7 @@ export function WoodlandPathTooltip({ name, children }) {
         const rect = e.currentTarget.getBoundingClientRect()
         setAnchor({ left: rect.left, top: rect.top, bottom: rect.bottom })
       }}
-      onMouseLeave={() => { setAnchor(null); setPos(null) }}
+      onMouseLeave={() => { setAnchor(null) }}
     >
       {children}
       {anchor && createPortal(
@@ -44,10 +45,10 @@ export function WoodlandPathTooltip({ name, children }) {
           ref={tooltipRef}
           style={{
             position: 'fixed',
-            left: pos ? pos.left : anchor.left,
-            top: pos ? pos.top : anchor.top,
+            left: anchor.left,
+            top: anchor.top,
             width: TOOLTIP_WIDTH,
-            visibility: pos ? 'visible' : 'hidden',
+            visibility: 'hidden',
             zIndex: 9999,
             pointerEvents: 'none',
           }}

--- a/src/hooks/useEncounterScores.js
+++ b/src/hooks/useEncounterScores.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { aggregateEncounterScores } from '../lib/encounterScores'
 
 export function useEncounterScores(groupId) {
   return useQuery({
@@ -7,19 +8,22 @@ export function useEncounterScores(groupId) {
     queryFn: async () => {
       let query = supabase
         .from('encounter_scores')
-        .select('id, encounter_name, creature_wins, player_wins')
+        .select('id, encounter_name, creature_wins, player_wins, group_id')
         .order('encounter_name')
 
       if (groupId) query = query.eq('group_id', groupId)
 
       const { data, error } = await query
       if (error) throw error
-      return (data ?? []).map((row) => ({
+      const rows = (data ?? []).map((row) => ({
         id: row.id,
         encounterName: row.encounter_name,
         creatureWins: row.creature_wins,
         playerWins: row.player_wins,
+        groupId: row.group_id,
       }))
+
+      return groupId ? rows : aggregateEncounterScores(rows)
     },
   })
 }

--- a/src/hooks/useUpdateEncounterScore.js
+++ b/src/hooks/useUpdateEncounterScore.js
@@ -4,8 +4,13 @@ import { supabase } from '../supabaseClient'
 export function useUpdateEncounterScore() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: async ({ encounterName, column, delta }) => {
+    mutationFn: async ({ groupId, encounterName, column, delta }) => {
+      if (!groupId) {
+        throw new Error('Select an active group before updating encounter counters.')
+      }
+
       const { data, error } = await supabase.rpc('increment_encounter_score', {
+        p_group_id: groupId,
         p_encounter_name: encounterName,
         p_column: column,
         p_delta: delta,

--- a/src/lib/encounterScores.js
+++ b/src/lib/encounterScores.js
@@ -1,0 +1,22 @@
+export function aggregateEncounterScores(rows) {
+  const totalsByEncounter = new Map()
+
+  for (const row of rows) {
+    const current = totalsByEncounter.get(row.encounterName) ?? {
+      id: `global-${row.encounterName}`,
+      encounterName: row.encounterName,
+      creatureWins: 0,
+      playerWins: 0,
+      groupId: null,
+    }
+
+    current.creatureWins += Number(row.creatureWins ?? 0)
+    current.playerWins += Number(row.playerWins ?? 0)
+
+    totalsByEncounter.set(row.encounterName, current)
+  }
+
+  return Array.from(totalsByEncounter.values()).sort((left, right) =>
+    left.encounterName.localeCompare(right.encounterName),
+  )
+}

--- a/src/lib/encounterScores.test.js
+++ b/src/lib/encounterScores.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { aggregateEncounterScores } from './encounterScores.js'
+
+test('aggregateEncounterScores combines encounter totals across groups', () => {
+  const rows = [
+    {
+      id: 'group-a-basilisk',
+      encounterName: 'Basilisk',
+      creatureWins: 2,
+      playerWins: 1,
+      groupId: 'group-a',
+    },
+    {
+      id: 'group-b-basilisk',
+      encounterName: 'Basilisk',
+      creatureWins: 5,
+      playerWins: 4,
+      groupId: 'group-b',
+    },
+    {
+      id: 'group-a-dark-fey',
+      encounterName: 'Dark Fey',
+      creatureWins: 1,
+      playerWins: 3,
+      groupId: 'group-a',
+    },
+  ]
+
+  assert.deepEqual(aggregateEncounterScores(rows), [
+    {
+      id: 'global-Basilisk',
+      encounterName: 'Basilisk',
+      creatureWins: 7,
+      playerWins: 5,
+      groupId: null,
+    },
+    {
+      id: 'global-Dark Fey',
+      encounterName: 'Dark Fey',
+      creatureWins: 1,
+      playerWins: 3,
+      groupId: null,
+    },
+  ])
+})

--- a/src/lib/groupNavigation.js
+++ b/src/lib/groupNavigation.js
@@ -1,0 +1,12 @@
+const GROUP_SETTINGS_PATH_RE = /^\/groups\/[^/]+\/settings\/?$/
+
+export function getGroupSwitchDestination({
+  currentPathname,
+  nextGroupId,
+  nextGroupAdminUserId,
+  userId,
+}) {
+  if (!GROUP_SETTINGS_PATH_RE.test(currentPathname)) return null
+  if (!nextGroupId) return '/'
+  return nextGroupAdminUserId === userId ? `/groups/${nextGroupId}/settings` : '/'
+}

--- a/src/lib/groupNavigation.test.js
+++ b/src/lib/groupNavigation.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getGroupSwitchDestination } from './groupNavigation.js'
+
+test('returns next group settings route when switching groups from settings as an admin', () => {
+  assert.equal(
+    getGroupSwitchDestination({
+      currentPathname: '/groups/current-group/settings',
+      nextGroupId: 'next-group',
+      nextGroupAdminUserId: 'user-1',
+      userId: 'user-1',
+    }),
+    '/groups/next-group/settings',
+  )
+})
+
+test('returns home when switching to a non-admin group from settings', () => {
+  assert.equal(
+    getGroupSwitchDestination({
+      currentPathname: '/groups/current-group/settings',
+      nextGroupId: 'next-group',
+      nextGroupAdminUserId: 'user-2',
+      userId: 'user-1',
+    }),
+    '/',
+  )
+})
+
+test('returns null when switching groups outside group settings', () => {
+  assert.equal(
+    getGroupSwitchDestination({
+      currentPathname: '/leaderboard',
+      nextGroupId: 'next-group',
+      nextGroupAdminUserId: 'user-1',
+      userId: 'user-1',
+    }),
+    null,
+  )
+})

--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -3,6 +3,7 @@ import { useEncounterScores } from '../hooks/useEncounterScores'
 import { useUpdateEncounterScore } from '../hooks/useUpdateEncounterScore'
 import { useActiveGroup } from '../hooks/useActiveGroup'
 import ScopeToggle from '../components/ScopeToggle'
+import GroupRequiredState from '../components/GroupRequiredState'
 
 const ENCOUNTERS = [
   {
@@ -38,21 +39,21 @@ function Crown() {
   )
 }
 
-function ScoreSide({ label, value, onIncrement, onDecrement, isPending, isWinning }) {
+function ScoreSide({ label, value, onIncrement, onDecrement, isPending, isWinning, readOnly }) {
   return (
     <div className="flex flex-col items-center gap-3">
       <div className="h-5">{isWinning && <Crown />}</div>
       <span className="text-xs font-body text-muted uppercase tracking-wider">{label}</span>
       <span className="font-display text-5xl text-gold tracking-wider tabular-nums">{value}</span>
       <div className="flex gap-2">
-        <ScoreButton label="-" onClick={onDecrement} disabled={isPending || value <= 0} />
-        <ScoreButton label="+" onClick={onIncrement} disabled={isPending} />
+        <ScoreButton label="-" onClick={onDecrement} disabled={readOnly || isPending || value <= 0} />
+        <ScoreButton label="+" onClick={onIncrement} disabled={readOnly || isPending} />
       </div>
     </div>
   )
 }
 
-function EncounterCard({ encounter, score, onUpdate, isPending }) {
+function EncounterCard({ encounter, score, onUpdate, isPending, readOnly }) {
   const creatureWins = score?.creatureWins ?? 0
   const playerWins = score?.playerWins ?? 0
 
@@ -73,6 +74,7 @@ function EncounterCard({ encounter, score, onUpdate, isPending }) {
           onDecrement={() => onUpdate(encounter.name, 'creature_wins', -1)}
           isPending={isPending}
           isWinning={creatureWins > playerWins}
+          readOnly={readOnly}
         />
 
         <div className="flex flex-col items-center gap-1 select-none">
@@ -86,6 +88,7 @@ function EncounterCard({ encounter, score, onUpdate, isPending }) {
           onDecrement={() => onUpdate(encounter.name, 'player_wins', -1)}
           isPending={isPending}
           isWinning={playerWins > creatureWins}
+          readOnly={readOnly}
         />
       </div>
     </div>
@@ -104,12 +107,23 @@ export default function Counters() {
   const groupId = scope === 'group' ? activeGroupId : null
   const { data: scores = [], error, isLoading } = useEncounterScores(groupId)
   const mutation = useUpdateEncounterScore()
+  const isReadOnly = scope !== 'group'
 
   const handleUpdate = (encounterName, column, delta) => {
-    mutation.mutate({ encounterName, column, delta })
+    if (isReadOnly || !activeGroupId) return
+    mutation.mutate({ groupId: activeGroupId, encounterName, column, delta })
   }
 
   const scoresByName = new Map(scores.map((s) => [s.encounterName, s]))
+
+  if (scope === 'group' && !activeGroupId) {
+    return (
+      <GroupRequiredState
+        title="Select a group to update encounter counters"
+        body="Global view shows the combined totals across your groups. Pick an active group when you want to edit its counters."
+      />
+    )
+  }
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -122,7 +136,9 @@ export default function Counters() {
           <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
         </div>
         <p className="text-muted text-sm font-body mt-3">
-          Running scoreboards for creature encounters.
+          {scope === 'group'
+            ? `Editing counters for ${activeGroup?.name ?? 'the active group'}.`
+            : 'Combined encounter totals across all of your groups. Switch to a group to edit.'}
         </p>
       </div>
 
@@ -142,6 +158,7 @@ export default function Counters() {
               score={scoresByName.get(encounter.name)}
               onUpdate={handleUpdate}
               isPending={mutation.isPending}
+              readOnly={isReadOnly}
             />
           ))}
         </div>

--- a/src/pages/Tierlist.jsx
+++ b/src/pages/Tierlist.jsx
@@ -109,7 +109,6 @@ function CharacterTile({ icon, onDragStart, onDragEnd, onHover, onTileDrop, isDr
 
 function CharacterCard({ iconKey, name, fallback }) {
   const [errored, setErrored] = useState(false)
-  useEffect(() => { setErrored(false) }, [iconKey])
   if (errored) return fallback
   return (
     <img
@@ -139,6 +138,7 @@ function CharacterDetailPanel({ icon }) {
       </div>
       <div className="w-full max-w-lg rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70">
         <CharacterCard
+          key={icon.key}
           iconKey={icon.key}
           name={icon.name}
           fallback={

--- a/supabase/migrations/20260422150000_encounter_scores_group_scoped.sql
+++ b/supabase/migrations/20260422150000_encounter_scores_group_scoped.sql
@@ -1,0 +1,96 @@
+-- Encounter counters are now group-scoped.
+-- Seed current groups, then require one row namespace per (group, encounter).
+
+alter table encounter_scores
+  drop constraint if exists encounter_scores_encounter_name_key;
+
+alter table encounter_scores
+  drop constraint if exists encounter_scores_group_id_fkey;
+
+alter table encounter_scores
+  add constraint encounter_scores_group_id_fkey
+  foreign key (group_id) references groups(id) on delete cascade;
+
+insert into encounter_scores (group_id, encounter_name)
+select g.id, encounters.encounter_name
+from groups g
+cross join (
+  values ('Basilisk'), ('Dark Fey')
+) as encounters(encounter_name)
+on conflict do nothing;
+
+do $$
+begin
+  if exists (select 1 from encounter_scores where group_id is null) then
+    raise exception 'encounter_scores.group_id still contains null rows; backfill before applying this migration';
+  end if;
+end;
+$$;
+
+alter table encounter_scores
+  alter column group_id set not null;
+
+create unique index if not exists encounter_scores_group_encounter_unique
+  on encounter_scores(group_id, encounter_name);
+
+create or replace function increment_encounter_score(
+  p_group_id uuid,
+  p_encounter_name text,
+  p_column text,
+  p_delta int
+)
+returns encounter_scores
+language plpgsql
+as $$
+declare
+  result encounter_scores;
+begin
+  if p_group_id is null then
+    raise exception 'p_group_id is required';
+  end if;
+
+  if p_column not in ('creature_wins', 'player_wins') then
+    raise exception 'invalid encounter score column: %', p_column;
+  end if;
+
+  insert into encounter_scores (group_id, encounter_name, creature_wins, player_wins)
+  values (
+    p_group_id,
+    p_encounter_name,
+    case when p_column = 'creature_wins' then greatest(0, p_delta) else 0 end,
+    case when p_column = 'player_wins' then greatest(0, p_delta) else 0 end
+  )
+  on conflict (group_id, encounter_name) do update set
+    creature_wins = case
+      when p_column = 'creature_wins'
+      then greatest(0, encounter_scores.creature_wins + p_delta)
+      else encounter_scores.creature_wins
+    end,
+    player_wins = case
+      when p_column = 'player_wins'
+      then greatest(0, encounter_scores.player_wins + p_delta)
+      else encounter_scores.player_wins
+    end
+  returning * into result;
+
+  return result;
+end;
+$$;
+
+drop policy if exists encounter_scores_select_all on encounter_scores;
+drop policy if exists encounter_scores_insert_all on encounter_scores;
+drop policy if exists encounter_scores_update_all on encounter_scores;
+drop policy if exists encounter_scores_delete_all on encounter_scores;
+
+create policy encounter_scores_select_same_group on encounter_scores
+  for select using (is_group_member(group_id, auth.uid()));
+
+create policy encounter_scores_insert_same_group on encounter_scores
+  for insert with check (is_group_member(group_id, auth.uid()));
+
+create policy encounter_scores_update_same_group on encounter_scores
+  for update using (is_group_member(group_id, auth.uid()))
+  with check (is_group_member(group_id, auth.uid()));
+
+create policy encounter_scores_delete_same_group on encounter_scores
+  for delete using (is_group_member(group_id, auth.uid()));


### PR DESCRIPTION
## What changed
- made encounter counters group-scoped in Supabase and pushed the migration to seed per-group Basilisk/Dark Fey rows for existing groups
- updated the counters page so `Group` mode edits the active group's counters while `Global` mode shows read-only aggregated totals across all groups
- fixed the group switcher so changing the active group while on group settings updates the route instead of leaving the page stuck on the previous group
- cleaned up the two remaining lint failures in `Tierlist` and `WoodlandPathTooltip`
- added focused node tests for encounter score aggregation and group-settings route switching

## Why
Issue #72 requires counters to be scoped by group, but the previous data model and RPC were still globally keyed by encounter name. That meant writes ignored the active group, and keeping the page-level global/group toggle would have produced mixed-group results. The follow-up switcher fix closes the UX gap discovered while testing the settings flow.

## Impact
- counter writes now land in the selected group only
- global counters remain visible as combined read-only totals across the user's groups
- switching active group from `/groups/:id/settings` now navigates to the newly selected group's settings when appropriate
- `npm run lint` is green again

## Validation
- `node --test src/lib/encounterScores.test.js`
- `node --test src/lib/groupNavigation.test.js`
- `npx eslint src/pages/Counters.jsx src/hooks/useEncounterScores.js src/hooks/useUpdateEncounterScore.js src/lib/encounterScores.js src/lib/encounterScores.test.js`
- `npx eslint src/components/WoodlandPathTooltip.jsx src/pages/Tierlist.jsx`
- `npx eslint src/components/GroupSwitcher.jsx src/lib/groupNavigation.js src/lib/groupNavigation.test.js`
- `npm run lint`
- `npm run build`
- `npx supabase db push`
