### PR TITLE
fix: correct MyCounter scope behavior and restore missing migration

### DIFF
--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -145,6 +145,9 @@ export default function Counters() {
       {error && (
         <p className="text-danger text-sm font-body mb-4">{error.message}</p>
       )}
+      {mutation.error && (
+        <p className="text-danger text-sm font-body mb-4">{mutation.error.message}</p>
+      )}
       {isLoading && (
         <p className="text-muted text-sm font-body italic">Loading...</p>
       )}
@@ -162,6 +165,11 @@ export default function Counters() {
             />
           ))}
         </div>
+      )}
+      {!groupId && !isLoading && (
+        <p className="text-muted text-xs font-body mt-4 text-center">
+          Global view is read-only. Switch to a group to update counters.
+        </p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- fix counter read scope so group view reads only the active group and global view aggregates all groups
- fix counter mutations to always target the active group and surface mutation errors in the UI
- restore missing migration \20260422150000_encounter_scores_group_scoped.sql\ so local/remote Supabase migration history is consistent

## Verification
- \
pm run build\
- \
px supabase db push\ (reports remote database is up to date)

## Notes
- Global counter view is now read-only by design; updates are enabled only when a group is selected.