### PR TITLE
feat: group guest players and active-group claim flow

### DIFF
--- a/src/hooks/useAddPlayer.js
+++ b/src/hooks/useAddPlayer.js
@@ -19,12 +19,16 @@ export function useAddPlayer() {
         p_favorite_character_id: favoriteCharacterId,
       })
       if (error) throw error
+
+      const created = Array.isArray(data) ? data[0] : data
+      if (!created?.id) throw new Error('Guest player was created but no id was returned.')
+
       return {
-        id: data.id,
-        name: data.name,
-        created_at: data.created_at,
-        icon_key: data.icon_key,
-        icon_character_id: data.icon_character_id,
+        id: created.id,
+        name: created.name,
+        created_at: created.created_at,
+        icon_key: created.icon_key,
+        icon_character_id: created.icon_character_id,
       }
     },
     onSuccess: () => {

--- a/src/hooks/useAddPlayer.js
+++ b/src/hooks/useAddPlayer.js
@@ -1,19 +1,31 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { useActiveGroup } from './useActiveGroup'
 
 export function useAddPlayer() {
   const queryClient = useQueryClient()
+  const { activeGroupId } = useActiveGroup()
   return useMutation({
     mutationFn: async ({ name, iconKey = null, iconCharacterId = null, favoriteCharacterId = null }) => {
       const trimmed = name.trim()
       if (!trimmed) throw new Error('Name is required')
-      const { data, error } = await supabase
-        .from('players')
-        .insert({ name: trimmed, icon_key: iconKey, icon_character_id: iconCharacterId, favorite_character_id: favoriteCharacterId })
-        .select('id, name, created_at, icon_key, icon_character_id')
-        .single()
+      if (!activeGroupId) throw new Error('Select an active group before adding a guest player.')
+
+      const { data, error } = await supabase.rpc('create_group_guest_player', {
+        p_group_id: activeGroupId,
+        p_name: trimmed,
+        p_icon_key: iconKey,
+        p_icon_character_id: iconCharacterId,
+        p_favorite_character_id: favoriteCharacterId,
+      })
       if (error) throw error
-      return data
+      return {
+        id: data.id,
+        name: data.name,
+        created_at: data.created_at,
+        icon_key: data.icon_key,
+        icon_character_id: data.icon_character_id,
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['players'] })

--- a/src/hooks/useClaimGuestPlayer.js
+++ b/src/hooks/useClaimGuestPlayer.js
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useActiveGroup } from './useActiveGroup'
+import { useAuth } from './useAuth'
+
+export function useClaimGuestPlayer() {
+  const queryClient = useQueryClient()
+  const { activeGroupId } = useActiveGroup()
+  const { user } = useAuth()
+
+  return useMutation({
+    mutationFn: async ({ guestPlayerId }) => {
+      if (!activeGroupId) throw new Error('Select an active group before claiming a guest player.')
+      const { data, error } = await supabase.rpc('claim_group_guest_player', {
+        p_group_id: activeGroupId,
+        p_guest_player_id: guestPlayerId,
+      })
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['players'] })
+      queryClient.invalidateQueries({ queryKey: ['currentPlayer', user?.id] })
+      queryClient.invalidateQueries({ queryKey: ['groupMembers', activeGroupId] })
+      queryClient.invalidateQueries({ queryKey: ['leaderboardStats'] })
+      queryClient.invalidateQueries({ queryKey: ['highscoreRecords'] })
+      queryClient.invalidateQueries({ queryKey: ['stats'] })
+      queryClient.invalidateQueries({ queryKey: ['games'] })
+      queryClient.invalidateQueries({ queryKey: ['tierlist'] })
+    },
+  })
+}

--- a/src/hooks/usePlayers.js
+++ b/src/hooks/usePlayers.js
@@ -27,16 +27,28 @@ export function usePlayers() {
     enabled: !groupsLoading && !currentLoading,
     queryFn: async () => {
       if (activeGroupId) {
-        const { data, error } = await supabase
-          .from('group_members')
-          .select(`players(${PLAYER_COLUMNS})`)
-          .eq('group_id', activeGroupId)
-        if (error) throw error
-        return data
+        const [membersRes, guestsRes] = await Promise.all([
+          supabase
+            .from('group_members')
+            .select(`players(${PLAYER_COLUMNS})`)
+            .eq('group_id', activeGroupId),
+          supabase
+            .from('group_guest_players')
+            .select(`players(${PLAYER_COLUMNS})`)
+            .eq('group_id', activeGroupId),
+        ])
+        if (membersRes.error) throw membersRes.error
+        if (guestsRes.error) throw guestsRes.error
+
+        const combined = [...(membersRes.data ?? []), ...(guestsRes.data ?? [])]
           .map((row) => row.players)
           .filter(Boolean)
           .map(normalize)
-          .sort((a, b) => a.name.localeCompare(b.name))
+
+        const byId = new Map()
+        for (const player of combined) byId.set(player.id, player)
+
+        return [...byId.values()].sort((a, b) => a.name.localeCompare(b.name))
       }
       if (!currentPlayer) return []
       return [normalize(currentPlayer)]

--- a/src/lib/accessControl.js
+++ b/src/lib/accessControl.js
@@ -19,7 +19,11 @@ export function canDeleteGame({ activeGroup, currentPlayer }) {
   return isGroupAdmin(activeGroup, currentPlayer)
 }
 
-export function canEditTierlist({ currentPlayer, playerId }) {
-  return Boolean(currentPlayer?.id && playerId && currentPlayer.id === playerId)
+export function canEditTierlist({ currentPlayer, player }) {
+  return Boolean(
+    currentPlayer?.user_id &&
+      player?.userId &&
+      currentPlayer.user_id === player.userId,
+  )
 }
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -38,6 +38,7 @@ export default function Login() {
             <input
               type="email"
               required
+              autoComplete="username"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
@@ -49,9 +50,10 @@ export default function Login() {
             <input
               type="password"
               required
+              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
+              placeholder="........"
               className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
             />
           </label>
@@ -60,7 +62,7 @@ export default function Login() {
             disabled={status === 'loading'}
             className="w-full px-4 py-2 bg-gold text-deep font-heading tracking-wide rounded disabled:opacity-50 hover:bg-gold-light transition-colors"
           >
-            {status === 'loading' ? 'Signing in…' : 'Sign in'}
+            {status === 'loading' ? 'Signing in...' : 'Sign in'}
           </button>
           {error && <p className="text-red-400 text-sm">{error}</p>}
         </form>

--- a/src/pages/Players.jsx
+++ b/src/pages/Players.jsx
@@ -75,7 +75,7 @@ export default function Players() {
 
   const playersQuery = usePlayers()
   const statsQuery = useLeaderboardStats()
-  const { activeGroupId, activeGroup } = useActiveGroup()
+  const { activeGroupId, activeGroup, groups, setActiveGroup } = useActiveGroup()
   const { data: allCharacters = [] } = useCharacters()
   const { data: currentPlayer } = useCurrentPlayer()
   const addPlayer = useAddPlayer()
@@ -108,6 +108,12 @@ export default function Players() {
 
   const openAddModal = () => {
     if (!activeGroupId) {
+      if (groups.length === 1) {
+        setActiveGroup(groups[0].id)
+        setUiError(null)
+        setShowAddModal(true)
+        return
+      }
       setUiError('Select an active group from the top-left switcher before adding a guest player.')
       return
     }
@@ -116,6 +122,7 @@ export default function Players() {
   }
 
   const handleAdd = () => {
+    setUiError(null)
     addPlayer.mutate({ name: newName, iconKey: newIconKey, iconCharacterId: newIconCharacterId, favoriteCharacterId: newFavoriteCharacterId }, {
       onSuccess: () => {
         setShowAddModal(false)
@@ -123,6 +130,9 @@ export default function Players() {
         setNewIconKey(null)
         setNewIconCharacterId(null)
         setNewFavoriteCharacterId(null)
+      },
+      onError: (err) => {
+        setUiError(err?.message ?? 'Failed to add guest player.')
       },
     })
   }
@@ -183,6 +193,11 @@ export default function Players() {
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>
         </div>
+        {activeGroup && (
+          <p className="text-muted text-xs font-body mt-2">
+            Active group: {activeGroup.name}
+          </p>
+        )}
         <p className="text-muted text-sm font-body mt-3">{players.length} adventurers registered</p>
         {!activeGroupId && (
           <p className="text-muted text-xs font-body mt-1">

--- a/src/pages/Players.jsx
+++ b/src/pages/Players.jsx
@@ -3,9 +3,11 @@ import { Link } from 'react-router-dom'
 import { usePlayers } from '../hooks/usePlayers'
 import { useLeaderboardStats } from '../hooks/useLeaderboardStats'
 import { useAddPlayer } from '../hooks/useAddPlayer'
+import { useClaimGuestPlayer } from '../hooks/useClaimGuestPlayer'
 import { useUpdatePlayer } from '../hooks/useUpdatePlayer'
 import { useCharacters } from '../hooks/useCharacters'
 import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
+import { useActiveGroup } from '../hooks/useActiveGroup'
 import { IconPicker } from '../components/IconPicker'
 import { AVAILABLE_ICONS } from '../data/availableIcons'
 
@@ -56,6 +58,7 @@ function PlayerAvatar({ iconKey, name, onClick, size = 'lg' }) {
 }
 
 export default function Players() {
+  const [uiError, setUiError] = useState(null)
   const [showAddModal, setShowAddModal] = useState(false)
   const [newName, setNewName] = useState('')
   const [newIconKey, setNewIconKey] = useState(null)
@@ -72,9 +75,11 @@ export default function Players() {
 
   const playersQuery = usePlayers()
   const statsQuery = useLeaderboardStats()
+  const { activeGroupId, activeGroup } = useActiveGroup()
   const { data: allCharacters = [] } = useCharacters()
   const { data: currentPlayer } = useCurrentPlayer()
   const addPlayer = useAddPlayer()
+  const claimGuestPlayer = useClaimGuestPlayer()
   const updatePlayer = useUpdatePlayer()
 
   const canEdit = (player) => !!currentPlayer && player.id === currentPlayer.id
@@ -99,7 +104,16 @@ export default function Players() {
     return { ...p, ...s }
   })
 
-  const error = playersQuery.error || statsQuery.error || addPlayer.error || updatePlayer.error
+  const error = playersQuery.error || statsQuery.error || addPlayer.error || claimGuestPlayer.error || updatePlayer.error
+
+  const openAddModal = () => {
+    if (!activeGroupId) {
+      setUiError('Select an active group from the top-left switcher before adding a guest player.')
+      return
+    }
+    setUiError(null)
+    setShowAddModal(true)
+  }
 
   const handleAdd = () => {
     addPlayer.mutate({ name: newName, iconKey: newIconKey, iconCharacterId: newIconCharacterId, favoriteCharacterId: newFavoriteCharacterId }, {
@@ -146,12 +160,23 @@ export default function Players() {
     updatePlayer.reset()
   }
 
+  const handleClaimGuest = (player) => {
+    if (!activeGroupId || player.userId) return
+    const ok = window.confirm(`Claim "${player.name}" for your account in ${activeGroup?.name ?? 'this group'}?`)
+    if (!ok) return
+    claimGuestPlayer.mutate({ guestPlayerId: player.id })
+  }
+
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-8 animate-fade-up">
         <div className="flex items-center justify-between">
           <h1 className="font-heading text-3xl text-parchment tracking-wide">Players</h1>
-          <button onClick={() => setShowAddModal(true)} className="btn-gold text-sm">
+          <button
+            onClick={openAddModal}
+            className="btn-gold text-sm"
+            title={!activeGroupId ? 'Select an active group to add guest players' : undefined}
+          >
             Add Player
           </button>
         </div>
@@ -159,10 +184,18 @@ export default function Players() {
           <span className="text-gold-dim">&#9670;</span>
         </div>
         <p className="text-muted text-sm font-body mt-3">{players.length} adventurers registered</p>
+        {!activeGroupId && (
+          <p className="text-muted text-xs font-body mt-1">
+            Select an active group to add or claim guest players.
+          </p>
+        )}
       </div>
 
       {error && (
         <p className="text-danger text-sm font-body mb-4">{error.message}</p>
+      )}
+      {uiError && (
+        <p className="text-danger text-sm font-body mb-4">{uiError}</p>
       )}
 
       {players.length === 0 && !playersQuery.isLoading ? (
@@ -187,6 +220,13 @@ export default function Players() {
                     <span className="font-heading text-lg text-parchment tracking-wide">
                       {player.name}
                     </span>
+                  )}
+                  {!player.userId && (
+                    <div className="mt-0.5">
+                      <span className="text-[10px] font-body uppercase tracking-wider text-teal-light/80">
+                        Guest
+                      </span>
+                    </div>
                   )}
                   <div className="mt-0.5">
                     <span className="text-muted text-xs font-body">Favourite Character</span>
@@ -223,12 +263,24 @@ export default function Players() {
                 <span className="text-muted">
                   Joined {new Date(player.createdAt).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
                 </span>
-                <Link
-                  to={`/players/${player.id}/tierlist`}
-                  className="text-gold-dim hover:text-gold transition-colors tracking-wide"
-                >
-                  Tierlist &rarr;
-                </Link>
+                <div className="flex items-center gap-3">
+                  {!player.userId && activeGroupId && (
+                    <button
+                      type="button"
+                      onClick={() => handleClaimGuest(player)}
+                      disabled={claimGuestPlayer.isPending}
+                      className="text-teal-light hover:text-teal transition-colors tracking-wide disabled:opacity-50"
+                    >
+                      {claimGuestPlayer.isPending ? 'Claiming...' : 'Claim'}
+                    </button>
+                  )}
+                  <Link
+                    to={`/players/${player.id}/tierlist`}
+                    className="text-gold-dim hover:text-gold transition-colors tracking-wide"
+                  >
+                    Tierlist &rarr;
+                  </Link>
+                </div>
               </div>
             </div>
           ))}

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -40,6 +40,7 @@ export default function Register() {
             <input
               type="email"
               required
+              autoComplete="username"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
@@ -51,9 +52,10 @@ export default function Register() {
             <input
               type="password"
               required
+              autoComplete="new-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="••••••••"
+              placeholder="........"
               className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
             />
           </label>
@@ -62,9 +64,10 @@ export default function Register() {
             <input
               type="password"
               required
+              autoComplete="new-password"
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
-              placeholder="••••••••"
+              placeholder="........"
               className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
             />
           </label>
@@ -73,7 +76,7 @@ export default function Register() {
             disabled={status === 'loading'}
             className="w-full px-4 py-2 bg-gold text-deep font-heading tracking-wide rounded disabled:opacity-50 hover:bg-gold-light transition-colors"
           >
-            {status === 'loading' ? 'Creating account…' : 'Create account'}
+            {status === 'loading' ? 'Creating account...' : 'Create account'}
           </button>
           {error && <p className="text-red-400 text-sm">{error}</p>}
         </form>

--- a/src/pages/Tierlist.jsx
+++ b/src/pages/Tierlist.jsx
@@ -303,7 +303,7 @@ export default function Tierlist() {
     () => (playersQuery.data ?? []).find(p => p.id === playerId),
     [playersQuery.data, playerId],
   )
-  const canEdit = canEditTierlist({ currentPlayer, playerId })
+  const canEdit = canEditTierlist({ currentPlayer, player })
 
   const iconsByKey = useMemo(() => {
     const map = new Map()

--- a/supabase/migrations/20260424123000_group_guest_players_and_claim.sql
+++ b/supabase/migrations/20260424123000_group_guest_players_and_claim.sql
@@ -1,0 +1,214 @@
+-- Group-scoped guest players and claim flow (issue #95).
+
+create table group_guest_players (
+  group_id             uuid not null references groups(id) on delete cascade,
+  player_id            uuid not null references players(id) on delete cascade,
+  created_by_user_id   uuid not null references auth.users(id) on delete cascade,
+  created_at           timestamptz not null default now(),
+  primary key (group_id, player_id)
+);
+
+create index group_guest_players_group_idx on group_guest_players(group_id);
+create index group_guest_players_player_idx on group_guest_players(player_id);
+
+alter table group_guest_players enable row level security;
+
+create policy group_guest_players_select_same_group on group_guest_players
+  for select using (is_group_member(group_id, auth.uid()));
+
+create policy group_guest_players_insert_member on group_guest_players
+  for insert with check (
+    created_by_user_id = auth.uid()
+    and is_group_member(group_id, auth.uid())
+    and exists (
+      select 1
+      from players p
+      where p.id = group_guest_players.player_id
+        and p.user_id is null
+    )
+  );
+
+create or replace function create_group_guest_player(
+  p_group_id uuid,
+  p_name text,
+  p_icon_key text default null,
+  p_icon_character_id uuid default null,
+  p_favorite_character_id uuid default null
+)
+returns players
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_name text := btrim(coalesce(p_name, ''));
+  v_player players%rowtype;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  if not is_group_member(p_group_id, v_user_id) then
+    raise exception 'not_group_member';
+  end if;
+
+  if v_name = '' then
+    raise exception 'name_required';
+  end if;
+
+  insert into players (
+    name,
+    icon_key,
+    icon_character_id,
+    favorite_character_id,
+    user_id
+  )
+  values (
+    v_name,
+    p_icon_key,
+    p_icon_character_id,
+    p_favorite_character_id,
+    null
+  )
+  returning * into v_player;
+
+  insert into group_guest_players (group_id, player_id, created_by_user_id)
+  values (p_group_id, v_player.id, v_user_id);
+
+  return v_player;
+end;
+$$;
+
+revoke all on function create_group_guest_player(uuid, text, text, uuid, uuid) from public;
+grant execute on function create_group_guest_player(uuid, text, text, uuid, uuid) to authenticated;
+
+create or replace function claim_group_guest_player(
+  p_group_id uuid,
+  p_guest_player_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_guest players%rowtype;
+  v_current players%rowtype;
+begin
+  if v_user_id is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  if not is_group_member(p_group_id, v_user_id) then
+    raise exception 'not_group_member';
+  end if;
+
+  if not exists (
+    select 1
+    from group_guest_players ggp
+    where ggp.group_id = p_group_id
+      and ggp.player_id = p_guest_player_id
+  ) then
+    raise exception 'guest_not_in_group';
+  end if;
+
+  select *
+  into v_guest
+  from players
+  where id = p_guest_player_id
+  for update;
+
+  if not found then
+    raise exception 'guest_not_found';
+  end if;
+
+  if v_guest.user_id is not null then
+    raise exception 'guest_already_linked';
+  end if;
+
+  select *
+  into v_current
+  from players
+  where user_id = v_user_id
+  for update;
+
+  if not found then
+    raise exception 'current_player_not_found';
+  end if;
+
+  if v_current.id = v_guest.id then
+    return v_guest.id;
+  end if;
+
+  -- Active-group only remap: keep this user's identity stable in the selected group.
+  update game_players gp
+  set player_id = v_guest.id
+  from games g
+  where gp.game_id = g.id
+    and g.group_id = p_group_id
+    and gp.player_id = v_current.id;
+
+  update game_highscores gh
+  set player_id = v_guest.id
+  from games g
+  where gh.game_id = g.id
+    and g.group_id = p_group_id
+    and gh.player_id = v_current.id;
+
+  update game_expansion_events gee
+  set player_id = v_guest.id
+  from games g
+  where gee.game_id = g.id
+    and g.group_id = p_group_id
+    and gee.player_id = v_current.id;
+
+  update game_player_deaths gpd
+  set player_id = v_guest.id
+  from games g
+  where gpd.game_id = g.id
+    and g.group_id = p_group_id
+    and gpd.player_id = v_current.id;
+
+  update game_player_deaths gpd
+  set killed_by_player_id = v_guest.id
+  from games g
+  where gpd.game_id = g.id
+    and g.group_id = p_group_id
+    and gpd.killed_by_player_id = v_current.id;
+
+  update group_members
+  set player_id = v_guest.id
+  where group_id = p_group_id
+    and user_id = v_user_id;
+
+  -- Move the current user's tierlist to the claimed identity to avoid data loss.
+  delete from tierlists where player_id = v_guest.id;
+  update tierlists
+  set player_id = v_guest.id
+  where player_id = v_current.id;
+
+  -- Preserve account-owned profile fields; guests do not edit their own profile data.
+  update players
+  set user_id = null
+  where id = v_current.id;
+
+  update players
+  set user_id = v_user_id,
+      name = v_current.name,
+      icon_key = v_current.icon_key,
+      icon_character_id = v_current.icon_character_id,
+      favorite_character_id = v_current.favorite_character_id
+  where id = v_guest.id;
+
+  delete from group_guest_players
+  where group_id = p_group_id
+    and player_id = v_guest.id;
+
+  return v_guest.id;
+end;
+$$;
+
+revoke all on function claim_group_guest_player(uuid, uuid) from public;
+grant execute on function claim_group_guest_player(uuid, uuid) to authenticated;


### PR DESCRIPTION
## Summary
- add group-scoped guest roster support with group_guest_players
- add SQL RPCs for guest creation and user-initiated claim in the active group
- wire Players UI and hooks for guest add/claim behavior
- update player loading to include both members and guests in active group
- align tierlist edit gating toward account ownership (user_id)
- improve login/register input autocomplete attributes to remove browser warnings

## Validation
- npm run lint
- npm run build
- npx supabase db push (applied migration 20260424123000_group_guest_players_and_claim.sql)

## Notes
- claim is implemented as active-group only, as requested
- unrelated local workspace files were intentionally not included in this branch