### PR TITLE
feat: multiple group admins + player avatar loading fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,4 +79,5 @@ Migrations live in `supabase/migrations/` and are applied via Supabase CLI. Seed
 - No Empty Criticism: If you spot a flaw, you must offer a mitigation.
 - Add Vector and Velocity: If you agree, expand. If you disagree, counter. Never just nod.
 - Be Thorough: Ask question when planning
+- Do not create or use git worktrees unless the user explicitly asks for a worktree.
 - Do not add or update tests unless the user explicitly asks for tests.

--- a/src/components/GroupSwitcher.jsx
+++ b/src/components/GroupSwitcher.jsx
@@ -1,13 +1,11 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useActiveGroup } from '../hooks/useActiveGroup'
-import { useAuth } from '../hooks/useAuth'
 import { useGroupJoinRequests } from '../hooks/useJoinRequests'
 import { getGroupSwitchDestination } from '../lib/groupNavigation'
 
 export default function GroupSwitcher({ onNavigate }) {
   const { activeGroup, groups, setActiveGroup } = useActiveGroup()
-  const { user } = useAuth()
   const [open, setOpen] = useState(false)
   const navigate = useNavigate()
   const location = useLocation()
@@ -26,7 +24,7 @@ export default function GroupSwitcher({ onNavigate }) {
 
   const label = activeGroup?.name ?? 'No group'
 
-  const isAdmin = activeGroup?.admin_user_id === user?.id
+  const isAdmin = Boolean(activeGroup?.isAdmin)
   const pendingGroupId = isAdmin ? activeGroup?.id : null
   const { data: pendingRequests = [] } = useGroupJoinRequests(pendingGroupId)
   const pendingCount = pendingRequests.length
@@ -36,8 +34,7 @@ export default function GroupSwitcher({ onNavigate }) {
     const destination = getGroupSwitchDestination({
       currentPathname: location.pathname,
       nextGroupId: nextGroup?.id ?? null,
-      nextGroupAdminUserId: nextGroup?.admin_user_id ?? null,
-      userId: user?.id ?? null,
+      nextGroupIsAdmin: Boolean(nextGroup?.isAdmin),
     })
 
     setActiveGroup(id)

--- a/src/hooks/useGroupMembers.js
+++ b/src/hooks/useGroupMembers.js
@@ -8,10 +8,12 @@ export function useGroupMembers(groupId) {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('group_members')
-        .select('user_id, players(id, name)')
+        .select('user_id, is_admin, players(id, name)')
         .eq('group_id', groupId)
       if (error) throw error
-      return data.map((row) => ({ userId: row.user_id, ...row.players })).filter((m) => m.id)
+      return data
+        .map((row) => ({ userId: row.user_id, isAdmin: Boolean(row.is_admin), ...row.players }))
+        .filter((m) => m.id)
     },
   })
 }
@@ -34,18 +36,20 @@ export function useRemoveMember(groupId) {
   })
 }
 
-export function useTransferAdmin(groupId) {
+export function useSetMemberAdmin(groupId) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (newAdminUserId) => {
-      const { error } = await supabase
-        .from('groups')
-        .update({ admin_user_id: newAdminUserId })
-        .eq('id', groupId)
+    mutationFn: async ({ userId, isAdmin }) => {
+      const { error } = await supabase.rpc('set_group_member_admin', {
+        p_group_id: groupId,
+        p_user_id: userId,
+        p_is_admin: isAdmin,
+      })
       if (error) throw error
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['groups'] })
+      qc.invalidateQueries({ queryKey: ['groupMembers', groupId] })
     },
   })
 }

--- a/src/hooks/useGroups.js
+++ b/src/hooks/useGroups.js
@@ -11,10 +11,18 @@ export function useGroups() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('group_members')
-        .select('groups(id, name, admin_user_id, invite_code)')
+        .select('is_admin, groups(id, name, admin_user_id, invite_code)')
         .eq('user_id', user.id)
       if (error) throw error
-      return data.map((row) => row.groups).filter(Boolean)
+      return data
+        .map((row) => {
+          if (!row.groups) return null
+          return {
+            ...row.groups,
+            isAdmin: Boolean(row.is_admin || row.groups.admin_user_id === user.id),
+          }
+        })
+        .filter(Boolean)
     },
   })
 }

--- a/src/lib/accessControl.js
+++ b/src/lib/accessControl.js
@@ -1,8 +1,11 @@
 function isGroupAdmin(activeGroup, currentPlayer) {
   return Boolean(
-    activeGroup?.admin_user_id &&
-      currentPlayer?.user_id &&
-      activeGroup.admin_user_id === currentPlayer.user_id,
+    activeGroup?.isAdmin ||
+      (
+        activeGroup?.admin_user_id &&
+        currentPlayer?.user_id &&
+        activeGroup.admin_user_id === currentPlayer.user_id
+      ),
   )
 }
 

--- a/src/lib/groupNavigation.js
+++ b/src/lib/groupNavigation.js
@@ -3,10 +3,9 @@ const GROUP_SETTINGS_PATH_RE = /^\/groups\/[^/]+\/settings\/?$/
 export function getGroupSwitchDestination({
   currentPathname,
   nextGroupId,
-  nextGroupAdminUserId,
-  userId,
+  nextGroupIsAdmin,
 }) {
   if (!GROUP_SETTINGS_PATH_RE.test(currentPathname)) return null
   if (!nextGroupId) return '/'
-  return nextGroupAdminUserId === userId ? `/groups/${nextGroupId}/settings` : '/'
+  return nextGroupIsAdmin ? `/groups/${nextGroupId}/settings` : '/'
 }

--- a/src/pages/CreateGroup.jsx
+++ b/src/pages/CreateGroup.jsx
@@ -44,7 +44,7 @@ export default function CreateGroup() {
 
     const { error: memberErr } = await supabase
       .from('group_members')
-      .insert({ group_id: group.id, user_id: user.id, player_id: player.id })
+      .insert({ group_id: group.id, user_id: user.id, player_id: player.id, is_admin: true })
     if (memberErr) {
       setError(memberErr.message)
       setSubmitting(false)

--- a/src/pages/GroupSettings.jsx
+++ b/src/pages/GroupSettings.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useParams, Navigate, useNavigate } from 'react-router-dom'
+import { useParams, Navigate } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { useAuth } from '../hooks/useAuth'
 import { useGroups } from '../hooks/useGroups'
@@ -17,7 +17,7 @@ import {
 import {
   useGroupMembers,
   useRemoveMember,
-  useTransferAdmin,
+  useSetMemberAdmin,
   useRenameGroup,
 } from '../hooks/useGroupMembers'
 
@@ -33,7 +33,6 @@ function relativeExpiry(iso) {
 export default function GroupSettings() {
   const { id: groupId } = useParams()
   const { user } = useAuth()
-  const navigate = useNavigate()
   const { data: groups = [], isLoading: groupsLoading } = useGroups()
   const group = groups.find((g) => g.id === groupId)
 
@@ -49,7 +48,7 @@ export default function GroupSettings() {
 
   const { data: members = [], isLoading: membersLoading } = useGroupMembers(groupId)
   const removeMember = useRemoveMember(groupId)
-  const transferAdmin = useTransferAdmin(groupId)
+  const setMemberAdmin = useSetMemberAdmin(groupId)
   const renameGroup = useRenameGroup(groupId)
 
   const { register, handleSubmit, reset, formState: { errors } } = useForm()
@@ -70,7 +69,7 @@ export default function GroupSettings() {
 
   if (groupsLoading) return <div className="p-8 text-parchment/60">Loading…</div>
   if (!group) return <Navigate to="/" replace />
-  if (group.admin_user_id !== user?.id) return <Navigate to="/" replace />
+  if (!group.isAdmin) return <Navigate to="/" replace />
 
   const joinUrl = `${window.location.origin}/join/${group.invite_code}`
 
@@ -99,13 +98,14 @@ export default function GroupSettings() {
     }
   }
 
-  const onTransferAdmin = async (member) => {
-    if (!window.confirm(`Transfer admin to ${member.name}? You will lose admin access.`)) return
+  const onSetMemberAdmin = async (member, makeAdmin) => {
+    if (!window.confirm(`${makeAdmin ? 'Grant' : 'Remove'} admin access for ${member.name}?`)) return
     try {
-      await transferAdmin.mutateAsync(member.userId)
-      navigate('/')
+      await setMemberAdmin.mutateAsync({ userId: member.userId, isAdmin: makeAdmin })
+      setToast(`${member.name} ${makeAdmin ? 'is now an admin' : 'is no longer an admin'}.`)
+      setTimeout(() => setToast(null), 2000)
     } catch (e) {
-      setToast(`Failed to transfer admin: ${e.message}`)
+      setToast(`Failed to update admin access: ${e.message}`)
       setTimeout(() => setToast(null), 3000)
     }
   }
@@ -127,9 +127,9 @@ export default function GroupSettings() {
     setFormError(null)
     const normalized = email.trim().toLowerCase()
 
-    // Q8-c: block self-invite by admin.
+    // Block self-invite for any admin.
     if (user?.email?.toLowerCase() === normalized) {
-      setFormError("That's you — you're the admin.")
+      setFormError("That's you — you're already in this group.")
       return
     }
 
@@ -183,7 +183,8 @@ export default function GroupSettings() {
         ) : (
           <ul className="divide-y divide-gold-dim/20 border border-gold-dim/20 rounded">
             {members.map((member) => {
-              const isAdmin = member.userId === group.admin_user_id
+              const isOwner = member.userId === group.admin_user_id
+              const isAdmin = isOwner || member.isAdmin
               const isSelf = member.userId === user?.id
               return (
                 <li key={member.userId} className="flex items-center justify-between px-4 py-3">
@@ -195,22 +196,26 @@ export default function GroupSettings() {
                   </div>
                   {!isSelf && (
                     <div className="flex gap-2">
-                      <button
-                        type="button"
-                        onClick={() => onTransferAdmin(member)}
-                        disabled={transferAdmin.isPending}
-                        className="text-sm text-parchment/70 hover:text-gold underline disabled:opacity-50"
-                      >
-                        Make admin
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onRemoveMember(member)}
-                        disabled={removeMember.isPending}
-                        className="text-sm text-red-300 hover:text-red-200 underline disabled:opacity-50"
-                      >
-                        Remove
-                      </button>
+                      {!isOwner && (
+                        <button
+                          type="button"
+                          onClick={() => onSetMemberAdmin(member, !isAdmin)}
+                          disabled={setMemberAdmin.isPending}
+                          className="text-sm text-parchment/70 hover:text-gold underline disabled:opacity-50"
+                        >
+                          {isAdmin ? 'Remove admin' : 'Make admin'}
+                        </button>
+                      )}
+                      {!isOwner && (
+                        <button
+                          type="button"
+                          onClick={() => onRemoveMember(member)}
+                          disabled={removeMember.isPending}
+                          className="text-sm text-red-300 hover:text-red-200 underline disabled:opacity-50"
+                        >
+                          Remove
+                        </button>
+                      )}
                     </div>
                   )}
                 </li>

--- a/src/pages/Players.jsx
+++ b/src/pages/Players.jsx
@@ -12,7 +12,27 @@ import { IconPicker } from '../components/IconPicker'
 import { AVAILABLE_ICONS } from '../data/availableIcons'
 
 const iconExtMap = new Map(AVAILABLE_ICONS.map(i => [i.key, i.ext]))
-function iconSrc(key) { return key ? `/icons/${key}${iconExtMap.get(key) ?? '.png'}` : null }
+function normalizeIconKey(rawKey) {
+  if (typeof rawKey !== 'string') return null
+  const trimmed = rawKey.trim()
+  if (!trimmed) return null
+
+  // Accept legacy values like "/icons/minstrel.jpg" or "minstrel.jpg".
+  const basename = trimmed.split('/').pop()?.split('\\').pop() ?? trimmed
+  const match = basename.match(/^(.*?)(\.(png|jpg|jpeg|webp))?$/i)
+  const key = (match?.[1] ?? basename).trim().toLowerCase()
+  const extFromValue = match?.[2]?.toLowerCase() ?? null
+  if (!key) return null
+
+  const ext = iconExtMap.get(key) ?? extFromValue ?? '.png'
+  return { key, ext }
+}
+
+function iconSrc(rawKey) {
+  const normalized = normalizeIconKey(rawKey)
+  if (!normalized) return null
+  return `/icons/${encodeURIComponent(normalized.key)}${normalized.ext}`
+}
 
 function PlayerAvatar({ iconKey, name, onClick, size = 'lg' }) {
   const dim = size === 'lg' ? 'w-20 h-20' : 'w-10 h-10'

--- a/supabase/migrations/20260424173000_multiple_group_admins.sql
+++ b/supabase/migrations/20260424173000_multiple_group_admins.sql
@@ -1,0 +1,267 @@
+-- Issue #91: support multiple admins per group.
+
+alter table group_members
+  add column if not exists is_admin boolean not null default false;
+
+-- Backfill existing owners as admins in their member row.
+update group_members gm
+set is_admin = true
+from groups g
+where g.id = gm.group_id
+  and g.admin_user_id = gm.user_id
+  and gm.is_admin is distinct from true;
+
+create index if not exists group_members_admin_idx
+  on group_members(group_id)
+  where is_admin = true;
+
+create or replace function is_group_admin(p_group_id uuid, p_user_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from groups g
+    where g.id = p_group_id
+      and g.admin_user_id = p_user_id
+  )
+  or exists (
+    select 1
+    from group_members gm
+    where gm.group_id = p_group_id
+      and gm.user_id = p_user_id
+      and gm.is_admin = true
+  );
+$$;
+
+revoke all on function is_group_admin(uuid, uuid) from public;
+grant execute on function is_group_admin(uuid, uuid) to authenticated;
+
+drop policy if exists groups_update_admin on groups;
+create policy groups_update_admin on groups
+  for update using (is_group_admin(id, auth.uid()))
+  with check (is_group_admin(id, auth.uid()));
+
+drop policy if exists groups_delete_admin on groups;
+create policy groups_delete_admin on groups
+  for delete using (is_group_admin(id, auth.uid()));
+
+drop policy if exists group_members_insert_self on group_members;
+create policy group_members_insert_self on group_members
+  for insert with check (
+    user_id = auth.uid()
+    and (
+      is_admin = false
+      or is_group_admin(group_id, auth.uid())
+    )
+  );
+
+drop policy if exists group_members_delete_self_or_admin on group_members;
+create policy group_members_delete_self_or_admin on group_members
+  for delete using (
+    user_id = auth.uid()
+    or (
+      is_group_admin(group_id, auth.uid())
+      and not exists (
+        select 1
+        from groups g
+        where g.id = group_members.group_id
+          and g.admin_user_id = group_members.user_id
+      )
+    )
+  );
+
+drop policy if exists group_invites_select_admin_or_target on group_invites;
+create policy group_invites_select_admin_or_target on group_invites
+  for select using (
+    is_group_admin(group_id, auth.uid())
+    or invited_email = lower(auth.jwt() ->> 'email')
+  );
+
+drop policy if exists group_invites_insert_admin on group_invites;
+create policy group_invites_insert_admin on group_invites
+  for insert with check (is_group_admin(group_id, auth.uid()));
+
+drop policy if exists group_invites_update_admin on group_invites;
+create policy group_invites_update_admin on group_invites
+  for update using (is_group_admin(group_id, auth.uid()));
+
+drop policy if exists group_invites_delete_admin on group_invites;
+create policy group_invites_delete_admin on group_invites
+  for delete using (is_group_admin(group_id, auth.uid()));
+
+drop policy if exists group_join_requests_select_admin_or_self on group_join_requests;
+create policy group_join_requests_select_admin_or_self on group_join_requests
+  for select using (
+    user_id = auth.uid()
+    or is_group_admin(group_id, auth.uid())
+  );
+
+drop policy if exists group_join_requests_update_admin on group_join_requests;
+create policy group_join_requests_update_admin on group_join_requests
+  for update using (is_group_admin(group_id, auth.uid()));
+
+drop policy if exists group_join_requests_delete_admin_or_self on group_join_requests;
+create policy group_join_requests_delete_admin_or_self on group_join_requests
+  for delete using (
+    user_id = auth.uid()
+    or is_group_admin(group_id, auth.uid())
+  );
+
+create or replace function can_edit_game(p_game_id uuid, p_user_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from games g
+    where g.id = p_game_id
+      and (
+        is_group_admin(g.group_id, p_user_id)
+        or exists (
+          select 1
+          from group_members gm
+          join game_players gp
+            on gp.player_id = gm.player_id
+           and gp.game_id = g.id
+          where gm.group_id = g.group_id
+            and gm.user_id = p_user_id
+        )
+      )
+  );
+$$;
+
+revoke all on function can_edit_game(uuid, uuid) from public;
+grant execute on function can_edit_game(uuid, uuid) to authenticated;
+
+drop policy if exists games_delete_admin_only on games;
+create policy games_delete_admin_only on games
+  for delete using (is_group_admin(group_id, auth.uid()));
+
+create or replace function get_pending_join_requests(p_group_id uuid)
+returns table(id uuid, user_id uuid, created_at timestamptz, player_name text)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select
+    gjr.id,
+    gjr.user_id,
+    gjr.created_at,
+    p.name as player_name
+  from group_join_requests gjr
+  left join players p on p.user_id = gjr.user_id
+  where gjr.group_id = p_group_id
+    and gjr.status = 'pending'
+    and is_group_admin(p_group_id, auth.uid())
+  order by gjr.created_at asc;
+$$;
+
+revoke all on function get_pending_join_requests(uuid) from public;
+grant execute on function get_pending_join_requests(uuid) to authenticated;
+
+create or replace function approve_join_request(p_request_id uuid)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_request  group_join_requests%rowtype;
+  v_player   uuid;
+  v_caller   uuid := auth.uid();
+  v_group_id uuid;
+begin
+  if v_caller is null then raise exception 'not_authenticated'; end if;
+
+  -- Read group_id without locking to verify admin before acquiring FOR UPDATE.
+  select group_id into v_group_id
+  from group_join_requests
+  where id = p_request_id;
+
+  if not found then raise exception 'request_not_found'; end if;
+
+  if not is_group_admin(v_group_id, v_caller) then
+    raise exception 'not_admin';
+  end if;
+
+  -- Now lock the row for the atomic update.
+  select * into v_request
+  from group_join_requests
+  where id = p_request_id
+  for update;
+
+  if v_request.status <> 'pending' then raise exception 'request_not_pending'; end if;
+
+  select id into v_player from players where user_id = v_request.user_id;
+  if v_player is null then raise exception 'no_player_profile'; end if;
+
+  insert into group_members (group_id, user_id, player_id)
+    values (v_request.group_id, v_request.user_id, v_player)
+    on conflict (group_id, user_id) do nothing;
+
+  update group_join_requests set status = 'approved' where id = p_request_id;
+
+  return v_request.group_id;
+end;
+$$;
+
+revoke all on function approve_join_request(uuid) from public;
+grant execute on function approve_join_request(uuid) to authenticated;
+
+create or replace function set_group_member_admin(
+  p_group_id uuid,
+  p_user_id uuid,
+  p_is_admin boolean
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+begin
+  if v_caller is null then
+    raise exception 'not_authenticated';
+  end if;
+
+  if not is_group_admin(p_group_id, v_caller) then
+    raise exception 'not_admin';
+  end if;
+
+  if not exists (
+    select 1
+    from group_members gm
+    where gm.group_id = p_group_id
+      and gm.user_id = p_user_id
+  ) then
+    raise exception 'member_not_found';
+  end if;
+
+  if exists (
+    select 1
+    from groups g
+    where g.id = p_group_id
+      and g.admin_user_id = p_user_id
+      and p_is_admin = false
+  ) then
+    raise exception 'cannot_demote_owner';
+  end if;
+
+  update group_members
+  set is_admin = p_is_admin
+  where group_id = p_group_id
+    and user_id = p_user_id;
+end;
+$$;
+
+revoke all on function set_group_member_admin(uuid, uuid, boolean) from public;
+grant execute on function set_group_member_admin(uuid, uuid, boolean) to authenticated;


### PR DESCRIPTION
## Summary
- add multi-admin support for groups via `group_members.is_admin`
- introduce `is_group_admin(...)` and update admin-gated policies/RPCs to use it
- add `set_group_member_admin(...)` RPC and wire Group Settings UI to promote/demote admins
- update group/admin client logic (`useGroups`, `GroupSwitcher`, access checks) for multi-admin behavior
- harden player avatar image URL generation so malformed legacy `icon_key` values still resolve safely
- add repo agent rule to avoid worktrees unless explicitly requested

## Verification
- `npm run lint`
- `npm run build`

## Notes
- keeps existing owner semantics (`groups.admin_user_id`) as protected owner row
- includes issue #91 scope plus the player-picture loading fix reported in this thread