### PR TITLE
feat: switch auth and group invites to username profiles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Layout from './components/Layout'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import Setup from './pages/Setup'
+import SetupUsername from './pages/SetupUsername'
 import CreateGroup from './pages/CreateGroup'
 import GroupSettings from './pages/GroupSettings'
 import JoinGroup from './pages/JoinGroup'
@@ -47,6 +48,7 @@ export default function App() {
             <Route path="/register" element={<Register />} />
             <Route element={<ProtectedLayout />}>
               <Route path="/setup" element={<Setup />} />
+              <Route path="/setup-username" element={<SetupUsername />} />
               <Route path="/groups/new" element={<CreateGroup />} />
               <Route path="/groups/:id/settings" element={<GroupSettings />} />
               <Route path="/join/:code" element={<JoinGroup />} />

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -1,16 +1,18 @@
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
+import { useCurrentUserProfile } from '../hooks/useCurrentUserProfile'
 
 export default function ProtectedRoute({ children }) {
   const { user, loading } = useAuth()
   const location = useLocation()
   const { data: player, isLoading: playerLoading } = useCurrentPlayer()
+  const { data: profile, isLoading: profileLoading } = useCurrentUserProfile()
 
-  if (loading || (user && playerLoading)) {
+  if (loading || (user && (playerLoading || profileLoading))) {
     return (
       <div className="min-h-screen flex items-center justify-center text-parchment bg-deep">
-        Loading…
+        Loading...
       </div>
     )
   }
@@ -26,6 +28,15 @@ export default function ProtectedRoute({ children }) {
   }
 
   if (player && location.pathname === '/setup') {
+    if (!profile) return <Navigate to="/setup-username" replace />
+    return <Navigate to="/" replace />
+  }
+
+  if (player && !profile && location.pathname !== '/setup-username') {
+    return <Navigate to="/setup-username" replace />
+  }
+
+  if (player && profile && location.pathname === '/setup-username') {
     return <Navigate to="/" replace />
   }
 

--- a/src/hooks/useCurrentUserProfile.js
+++ b/src/hooks/useCurrentUserProfile.js
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from './useAuth'
+
+export function useCurrentUserProfile() {
+  const { user } = useAuth()
+
+  return useQuery({
+    queryKey: ['currentUserProfile', user?.id],
+    enabled: !!user,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('user_id, username, created_at')
+        .eq('user_id', user.id)
+        .maybeSingle()
+      if (error) throw error
+      return data
+    },
+  })
+}

--- a/src/hooks/useGroupInvites.js
+++ b/src/hooks/useGroupInvites.js
@@ -1,25 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 
-// Reads all invites for a group (admin only, enforced by RLS).
+// Reads group invites for admins via SECURITY DEFINER RPC.
 // includeHistory=true extends to revoked/accepted/expired in the last 30 days.
 export function useGroupInvites(groupId, { includeHistory = false } = {}) {
   return useQuery({
     queryKey: ['groupInvites', groupId, includeHistory],
     enabled: !!groupId,
     queryFn: async () => {
-      let q = supabase
-        .from('group_invites')
-        .select('id, invited_email, status, expires_at, created_at')
-        .eq('group_id', groupId)
-        .order('created_at', { ascending: false })
-      if (!includeHistory) {
-        q = q.eq('status', 'pending')
-      } else {
-        const cutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
-        q = q.gte('created_at', cutoff)
-      }
-      const { data, error } = await q
+      const { data, error } = await supabase.rpc('get_group_invites_for_admin', {
+        p_group_id: groupId,
+        p_include_history: includeHistory,
+      })
       if (error) throw error
       return data
     },
@@ -31,38 +23,23 @@ function newToken() {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
 }
 
-// Upsert-by-hand: SELECT existing pending row -> UPDATE or INSERT.
-// Avoids ON CONFLICT against a partial unique index.
-export function useCreateEmailInvite(groupId) {
+// Create (or refresh) a pending invite for an existing username.
+export function useCreateUsernameInvite(groupId) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async (rawEmail) => {
-      const email = rawEmail.trim().toLowerCase()
+    mutationFn: async (rawUsername) => {
+      const username = rawUsername.trim().toLowerCase()
       const token = newToken()
       const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
 
-      const { data: existing, error: selErr } = await supabase
-        .from('group_invites')
-        .select('id')
-        .eq('group_id', groupId)
-        .eq('invited_email', email)
-        .eq('status', 'pending')
-        .maybeSingle()
-      if (selErr) throw selErr
-
-      if (existing) {
-        const { error: updErr } = await supabase
-          .from('group_invites')
-          .update({ token, expires_at: expiresAt })
-          .eq('id', existing.id)
-        if (updErr) throw updErr
-      } else {
-        const { error: insErr } = await supabase
-          .from('group_invites')
-          .insert({ group_id: groupId, invited_email: email, token, status: 'pending', expires_at: expiresAt })
-        if (insErr) throw insErr
-      }
-      return email
+      const { data, error } = await supabase.rpc('create_group_invite_by_username', {
+        p_group_id: groupId,
+        p_username: username,
+        p_token: token,
+        p_expires_at: expiresAt,
+      })
+      if (error) throw error
+      return data?.[0]?.invited_username ?? username
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['groupInvites', groupId] }),
   })

--- a/src/hooks/usePendingInvites.js
+++ b/src/hooks/usePendingInvites.js
@@ -3,7 +3,7 @@ import { supabase } from '../supabaseClient'
 import { useAuth } from './useAuth'
 import { useCurrentPlayer } from './useCurrentPlayer'
 
-// Invites addressed to the current user's email, pending, not expired.
+// Invites addressed to the current user, pending, not expired.
 // Uses a SECURITY DEFINER RPC so the group name comes back even though the
 // invitee isn't a group member yet (the groups select policy is members-only).
 export function usePendingInvites() {

--- a/src/pages/GroupSettings.jsx
+++ b/src/pages/GroupSettings.jsx
@@ -3,9 +3,10 @@ import { useParams, Navigate } from 'react-router-dom'
 import { useForm } from 'react-hook-form'
 import { useAuth } from '../hooks/useAuth'
 import { useGroups } from '../hooks/useGroups'
+import { useCurrentUserProfile } from '../hooks/useCurrentUserProfile'
 import {
   useGroupInvites,
-  useCreateEmailInvite,
+  useCreateUsernameInvite,
   useRevokeInvite,
   useRegenerateInviteCode,
 } from '../hooks/useGroupInvites'
@@ -36,15 +37,24 @@ function isDuplicateGroupNameError(error) {
   return details.includes('groups_name_unique_ci') || details.includes('lower(btrim(name))')
 }
 
+function mapInviteError(error) {
+  const code = `${error?.message ?? ''}`.toLowerCase()
+  if (code.includes('username_not_found')) return 'Username does not exist.'
+  if (code.includes('cannot_invite_self')) return "That's you - you're already in this group."
+  if (code.includes('not_admin')) return 'Only group admins can send invites.'
+  return error?.message ?? 'Failed to create invite.'
+}
+
 export default function GroupSettings() {
   const { id: groupId } = useParams()
   const { user } = useAuth()
+  const { data: profile } = useCurrentUserProfile()
   const { data: groups = [], isLoading: groupsLoading } = useGroups()
   const group = groups.find((g) => g.id === groupId)
 
   const [showHistory, setShowHistory] = useState(false)
   const { data: invites = [], isLoading: invitesLoading } = useGroupInvites(groupId, { includeHistory: showHistory })
-  const createInvite = useCreateEmailInvite(groupId)
+  const createInvite = useCreateUsernameInvite(groupId)
   const revokeInvite = useRevokeInvite(groupId)
   const regenerate = useRegenerateInviteCode(groupId)
 
@@ -73,7 +83,7 @@ export default function GroupSettings() {
     if (group?.name) resetRename({ name: group.name })
   }, [group?.name]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (groupsLoading) return <div className="p-8 text-parchment/60">Loading…</div>
+  if (groupsLoading) return <div className="p-8 text-parchment/60">Loading...</div>
   if (!group) return <Navigate to="/" replace />
   if (!group.isAdmin) return <Navigate to="/" replace />
 
@@ -133,23 +143,22 @@ export default function GroupSettings() {
     setTimeout(() => setToast(null), 2000)
   }
 
-  const onInvite = handleSubmit(async ({ email }) => {
+  const onInvite = handleSubmit(async ({ username }) => {
     setFormError(null)
-    const normalized = email.trim().toLowerCase()
+    const normalized = username.trim().toLowerCase()
 
-    // Block self-invite for any admin.
-    if (user?.email?.toLowerCase() === normalized) {
-      setFormError("That's you — you're already in this group.")
+    if (profile?.username === normalized) {
+      setFormError("That's you - you're already in this group.")
       return
     }
 
     try {
-      await createInvite.mutateAsync(normalized)
-      reset({ email: '' })
-      setToast('Invite created — user will see it next time they log in.')
+      const invitedUsername = await createInvite.mutateAsync(normalized)
+      reset({ username: '' })
+      setToast(`Invite created for @${invitedUsername}.`)
       setTimeout(() => setToast(null), 3000)
     } catch (e) {
-      setFormError(e.message ?? 'Failed to create invite.')
+      setFormError(mapInviteError(e))
     }
   })
 
@@ -175,7 +184,7 @@ export default function GroupSettings() {
             disabled={renameGroup.isPending}
             className="px-4 py-2 bg-gold text-deep font-heading rounded hover:bg-gold-light transition-colors"
           >
-            {renameGroup.isPending ? 'Saving…' : 'Save'}
+            {renameGroup.isPending ? 'Saving...' : 'Save'}
           </button>
         </form>
         {renameErrors.name && <p className="text-red-400 text-sm">{renameErrors.name.message}</p>}
@@ -187,7 +196,7 @@ export default function GroupSettings() {
           Members{members.length > 0 ? ` (${members.length})` : ''}
         </h2>
         {membersLoading ? (
-          <p className="text-parchment/50 text-sm">Loading…</p>
+          <p className="text-parchment/50 text-sm">Loading...</p>
         ) : members.length === 0 ? (
           <p className="text-parchment/50 text-sm italic">No members.</p>
         ) : (
@@ -258,17 +267,17 @@ export default function GroupSettings() {
           disabled={regenerate.isPending}
           className="text-sm text-parchment/70 hover:text-gold underline"
         >
-          {regenerate.isPending ? 'Regenerating…' : 'Regenerate link'}
+          {regenerate.isPending ? 'Regenerating...' : 'Regenerate link'}
         </button>
       </section>
 
       <section className="space-y-3">
-        <h2 className="font-heading text-xl text-parchment">Invite by email</h2>
+        <h2 className="font-heading text-xl text-parchment">Invite by username</h2>
         <form onSubmit={onInvite} className="flex gap-2">
           <input
-            type="email"
-            placeholder="friend@example.com"
-            {...register('email', { required: 'Email required' })}
+            type="text"
+            placeholder="friend_username"
+            {...register('username', { required: 'Username required' })}
             className="flex-1 px-3 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded"
           />
           <button
@@ -276,10 +285,10 @@ export default function GroupSettings() {
             disabled={createInvite.isPending}
             className="px-4 py-2 bg-gold text-deep font-heading rounded hover:bg-gold-light transition-colors"
           >
-            {createInvite.isPending ? 'Sending…' : 'Send invite'}
+            {createInvite.isPending ? 'Sending...' : 'Send invite'}
           </button>
         </form>
-        {errors.email && <p className="text-red-400 text-sm">{errors.email.message}</p>}
+        {errors.username && <p className="text-red-400 text-sm">{errors.username.message}</p>}
         {formError && <p className="text-red-400 text-sm">{formError}</p>}
       </section>
 
@@ -295,7 +304,7 @@ export default function GroupSettings() {
           </button>
         </div>
         {invitesLoading ? (
-          <p className="text-parchment/50 text-sm">Loading…</p>
+          <p className="text-parchment/50 text-sm">Loading...</p>
         ) : invites.length === 0 ? (
           <p className="text-parchment/50 text-sm italic">No {showHistory ? 'invites' : 'pending invites'}.</p>
         ) : (
@@ -303,7 +312,7 @@ export default function GroupSettings() {
             {invites.map((inv) => (
               <li key={inv.id} className="flex items-center justify-between px-4 py-3">
                 <div>
-                  <div className="text-parchment">{inv.invited_email}</div>
+                  <div className="text-parchment">{inv.invited_username ? `@${inv.invited_username}` : 'Unknown user'}</div>
                   <div className="text-xs text-parchment/50 font-body">
                     {inv.status === 'pending' ? relativeExpiry(inv.expires_at) : inv.status}
                   </div>
@@ -328,7 +337,7 @@ export default function GroupSettings() {
           Join requests{joinRequests.length > 0 ? ` (${joinRequests.length})` : ''}
         </h2>
         {joinRequestsLoading ? (
-          <p className="text-parchment/50 text-sm">Loading…</p>
+          <p className="text-parchment/50 text-sm">Loading...</p>
         ) : joinRequests.length === 0 ? (
           <p className="text-parchment/50 text-sm italic">No pending requests.</p>
         ) : (

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -3,8 +3,12 @@ import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
 import { sanitizeNext } from '../utils/redirect'
 
+function normalizeUsername(value) {
+  return value.trim().toLowerCase()
+}
+
 export default function Login() {
-  const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [status, setStatus] = useState('idle')
   const [error, setError] = useState(null)
@@ -16,13 +20,26 @@ export default function Login() {
     e.preventDefault()
     setStatus('loading')
     setError(null)
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
-    if (error) {
-      setError(error.message)
+
+    const normalizedUsername = normalizeUsername(username)
+
+    const { data: email, error: resolveError } = await supabase
+      .rpc('get_email_for_username', { p_username: normalizedUsername })
+
+    if (resolveError || !email) {
+      setError('Invalid username or password.')
       setStatus('idle')
-    } else {
-      navigate(next, { replace: true })
+      return
     }
+
+    const { error: signInError } = await supabase.auth.signInWithPassword({ email, password })
+    if (signInError) {
+      setError('Invalid username or password.')
+      setStatus('idle')
+      return
+    }
+
+    navigate(next, { replace: true })
   }
 
   return (
@@ -34,14 +51,13 @@ export default function Login() {
         </div>
         <form onSubmit={onSubmit} className="space-y-4">
           <label className="block">
-            <span className="block text-sm text-parchment/80 mb-1 font-heading">Email</span>
+            <span className="block text-sm text-parchment/80 mb-1 font-heading">Username</span>
             <input
-              type="email"
               required
               autoComplete="username"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="your_name"
               className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
             />
           </label>

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -2,7 +2,16 @@ import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
 
+function normalizeUsername(value) {
+  return value.trim().toLowerCase()
+}
+
+function isValidUsername(value) {
+  return /^[a-z0-9_]{3,20}$/.test(value)
+}
+
 export default function Register() {
+  const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
@@ -16,15 +25,58 @@ export default function Register() {
       setError('Passwords do not match.')
       return
     }
+
+    const normalizedUsername = normalizeUsername(username)
+    if (!isValidUsername(normalizedUsername)) {
+      setError('Username must be 3-20 chars: lowercase letters, numbers, underscores.')
+      return
+    }
+
     setStatus('loading')
     setError(null)
-    const { error } = await supabase.auth.signUp({ email, password })
-    if (error) {
-      setError(error.message)
+
+    const { data: usernameOwner, error: usernameLookupError } = await supabase.rpc('get_email_for_username', {
+      p_username: normalizedUsername,
+    })
+    if (usernameLookupError) {
+      setError(usernameLookupError.message)
       setStatus('idle')
-    } else {
-      navigate('/', { replace: true })
+      return
     }
+    if (usernameOwner) {
+      setError('That username is already taken.')
+      setStatus('idle')
+      return
+    }
+
+    const { data: signUpData, error: signUpError } = await supabase.auth.signUp({ email, password })
+    if (signUpError) {
+      setError(signUpError.message)
+      setStatus('idle')
+      return
+    }
+
+    const newUserId = signUpData?.user?.id
+    if (!newUserId) {
+      navigate('/login', { replace: true })
+      return
+    }
+
+    const { error: profileError } = await supabase
+      .from('user_profiles')
+      .insert({ user_id: newUserId, username: normalizedUsername })
+
+    if (profileError) {
+      if (profileError.code === '23505') {
+        setError('That username is already taken.')
+      } else {
+        setError(profileError.message)
+      }
+      setStatus('idle')
+      return
+    }
+
+    navigate('/', { replace: true })
   }
 
   return (
@@ -36,11 +88,24 @@ export default function Register() {
         </div>
         <form onSubmit={onSubmit} className="space-y-4">
           <label className="block">
+            <span className="block text-sm text-parchment/80 mb-1 font-heading">Username</span>
+            <input
+              required
+              minLength={3}
+              maxLength={20}
+              autoComplete="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="your_name"
+              className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
+            />
+          </label>
+          <label className="block">
             <span className="block text-sm text-parchment/80 mb-1 font-heading">Email</span>
             <input
               type="email"
               required
-              autoComplete="username"
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"

--- a/src/pages/SetupUsername.jsx
+++ b/src/pages/SetupUsername.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+import { useAuth } from '../hooks/useAuth'
+
+function normalizeUsername(value) {
+  return value.trim().toLowerCase()
+}
+
+function isValidUsername(value) {
+  return /^[a-z0-9_]{3,20}$/.test(value)
+}
+
+export default function SetupUsername() {
+  const { user } = useAuth()
+  const qc = useQueryClient()
+  const navigate = useNavigate()
+  const [username, setUsername] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState(null)
+
+  const onSubmit = async (e) => {
+    e.preventDefault()
+    const normalized = normalizeUsername(username)
+    if (!isValidUsername(normalized)) {
+      setError('Use 3-20 chars: lowercase letters, numbers, underscores.')
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    const { error: upsertError } = await supabase
+      .from('user_profiles')
+      .upsert({ user_id: user.id, username: normalized }, { onConflict: 'user_id' })
+
+    if (upsertError) {
+      if (upsertError.code === '23505') {
+        setError('That username is already taken.')
+      } else {
+        setError(upsertError.message)
+      }
+      setSubmitting(false)
+      return
+    }
+
+    await qc.invalidateQueries({ queryKey: ['currentUserProfile', user.id] })
+    navigate('/', { replace: true })
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-deep">
+      <div className="max-w-md w-full space-y-6">
+        <div className="space-y-2">
+          <h1 className="font-display text-3xl text-gold tracking-wider">Choose a username</h1>
+          <p className="text-parchment/80 font-body">
+            Your username is used for sign-in and group invites.
+          </p>
+        </div>
+        <form onSubmit={onSubmit} className="space-y-4">
+          <label className="block">
+            <span className="block text-sm text-parchment/80 mb-1 font-heading">Username</span>
+            <input
+              required
+              minLength={3}
+              maxLength={20}
+              autoComplete="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="your_name"
+              className="w-full px-4 py-2 bg-deep-light/60 border border-gold-dim/40 text-parchment rounded focus:outline-none focus:border-gold"
+            />
+          </label>
+          <p className="text-parchment/60 text-xs font-body">
+            Allowed: lowercase letters, numbers, underscores.
+          </p>
+          <button
+            type="submit"
+            disabled={submitting || !username.trim()}
+            className="w-full px-4 py-2 bg-gold text-deep font-heading tracking-wide rounded disabled:opacity-50 hover:bg-gold-light transition-colors"
+          >
+            {submitting ? 'Saving...' : 'Continue'}
+          </button>
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/supabase/migrations/20260425153000_user_profiles_and_username_invites.sql
+++ b/supabase/migrations/20260425153000_user_profiles_and_username_invites.sql
@@ -1,0 +1,241 @@
+-- Issue #105: move identity concerns to user_profiles and switch invite/login to username-first.
+
+create table if not exists user_profiles (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  username text not null,
+  created_at timestamptz not null default now(),
+  constraint user_profiles_username_lowercase
+    check (username = lower(username)),
+  constraint user_profiles_username_format
+    check (username ~ '^[a-z0-9_]{3,20}$')
+);
+
+create unique index if not exists user_profiles_username_unique_ci
+  on user_profiles (lower(username));
+
+alter table user_profiles enable row level security;
+
+drop policy if exists user_profiles_select_self on user_profiles;
+create policy user_profiles_select_self on user_profiles
+  for select using (user_id = auth.uid());
+
+drop policy if exists user_profiles_insert_self on user_profiles;
+create policy user_profiles_insert_self on user_profiles
+  for insert with check (user_id = auth.uid());
+
+drop policy if exists user_profiles_update_self on user_profiles;
+create policy user_profiles_update_self on user_profiles
+  for update using (user_id = auth.uid()) with check (user_id = auth.uid());
+
+alter table group_invites
+  add column if not exists invited_user_id uuid references user_profiles(user_id) on delete cascade;
+
+alter table group_invites
+  alter column invited_email drop not null;
+
+create index if not exists group_invites_invited_user_idx
+  on group_invites(invited_user_id);
+
+create unique index if not exists group_invites_one_pending_per_user
+  on group_invites (group_id, invited_user_id)
+  where status = 'pending' and invited_user_id is not null;
+
+drop policy if exists group_invites_select_admin_or_target on group_invites;
+create policy group_invites_select_admin_or_target on group_invites
+  for select using (
+    is_group_admin(group_id, auth.uid())
+    or (
+      invited_user_id = auth.uid()
+      and status = 'pending'
+      and expires_at > now()
+    )
+  );
+
+drop policy if exists group_invites_update_target_decline on group_invites;
+create policy group_invites_update_target_decline on group_invites
+  for update using (
+    invited_user_id = auth.uid()
+    and status = 'pending'
+  ) with check (status = 'revoked');
+
+create or replace function get_email_for_username(p_username text)
+returns text
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select lower(au.email)
+  from user_profiles up
+  join auth.users au on au.id = up.user_id
+  where up.username = lower(trim(p_username))
+  limit 1;
+$$;
+
+revoke all on function get_email_for_username(text) from public;
+grant execute on function get_email_for_username(text) to anon, authenticated;
+
+create or replace function create_group_invite_by_username(
+  p_group_id uuid,
+  p_username text,
+  p_token text,
+  p_expires_at timestamptz default null
+)
+returns table(id uuid, invited_username text)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_caller uuid := auth.uid();
+  v_target_user_id uuid;
+  v_target_username text;
+  v_existing_id uuid;
+  v_expires_at timestamptz := coalesce(p_expires_at, now() + interval '7 days');
+begin
+  if v_caller is null then raise exception 'not_authenticated'; end if;
+  if not is_group_admin(p_group_id, v_caller) then raise exception 'not_admin'; end if;
+
+  if coalesce(length(trim(p_token)), 0) < 16 then
+    raise exception 'invalid_token';
+  end if;
+
+  select up.user_id, up.username
+  into v_target_user_id, v_target_username
+  from user_profiles up
+  where up.username = lower(trim(p_username))
+  limit 1;
+
+  if v_target_user_id is null then raise exception 'username_not_found'; end if;
+  if v_target_user_id = v_caller then raise exception 'cannot_invite_self'; end if;
+
+  select gi.id
+  into v_existing_id
+  from group_invites gi
+  where gi.group_id = p_group_id
+    and gi.invited_user_id = v_target_user_id
+    and gi.status = 'pending'
+  for update;
+
+  if v_existing_id is null then
+    insert into group_invites (group_id, invited_user_id, token, status, expires_at)
+    values (p_group_id, v_target_user_id, p_token, 'pending', v_expires_at)
+    returning group_invites.id into v_existing_id;
+  else
+    update group_invites
+    set token = p_token,
+        expires_at = v_expires_at
+    where group_invites.id = v_existing_id;
+  end if;
+
+  return query
+  select v_existing_id, v_target_username;
+end;
+$$;
+
+revoke all on function create_group_invite_by_username(uuid, text, text, timestamptz) from public;
+grant execute on function create_group_invite_by_username(uuid, text, text, timestamptz) to authenticated;
+
+create or replace function get_group_invites_for_admin(
+  p_group_id uuid,
+  p_include_history boolean default false
+)
+returns table(
+  id uuid,
+  invited_user_id uuid,
+  invited_username text,
+  status text,
+  expires_at timestamptz,
+  created_at timestamptz
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select
+    gi.id,
+    gi.invited_user_id,
+    up.username as invited_username,
+    gi.status,
+    gi.expires_at,
+    gi.created_at
+  from group_invites gi
+  left join user_profiles up on up.user_id = gi.invited_user_id
+  where gi.group_id = p_group_id
+    and is_group_admin(p_group_id, auth.uid())
+    and (
+      (not coalesce(p_include_history, false) and gi.status = 'pending')
+      or (coalesce(p_include_history, false) and gi.created_at >= now() - interval '30 days')
+    )
+  order by gi.created_at desc;
+$$;
+
+revoke all on function get_group_invites_for_admin(uuid, boolean) from public;
+grant execute on function get_group_invites_for_admin(uuid, boolean) to authenticated;
+
+-- Atomic: verify invite -> insert group_members -> mark invite accepted.
+create or replace function accept_group_invite(p_token text)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite   group_invites%rowtype;
+  v_user_id  uuid := auth.uid();
+  v_player   uuid;
+begin
+  if v_user_id is null then raise exception 'not_authenticated'; end if;
+
+  select * into v_invite from group_invites where token = p_token for update;
+
+  if not found then raise exception 'invite_not_found'; end if;
+  if v_invite.status <> 'pending' then raise exception 'invite_not_pending'; end if;
+  if v_invite.expires_at <= now() then raise exception 'invite_expired'; end if;
+  if v_invite.invited_user_id is distinct from v_user_id then raise exception 'invite_target_mismatch'; end if;
+
+  select id into v_player from players where user_id = v_user_id;
+  if v_player is null then raise exception 'no_player_profile'; end if;
+
+  insert into group_members (group_id, user_id, player_id)
+    values (v_invite.group_id, v_user_id, v_player)
+    on conflict (group_id, user_id) do nothing;
+
+  update group_invites
+    set status = 'accepted'
+    where group_id = v_invite.group_id
+      and invited_user_id = v_user_id
+      and status = 'pending';
+
+  return v_invite.group_id;
+end;
+$$;
+
+revoke all on function accept_group_invite(text) from public;
+grant execute on function accept_group_invite(text) to authenticated;
+
+create or replace function get_pending_invites_for_me()
+returns table (
+  id uuid,
+  token text,
+  group_id uuid,
+  expires_at timestamptz,
+  group_name text
+)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select gi.id, gi.token, gi.group_id, gi.expires_at, g.name as group_name
+  from group_invites gi
+  join groups g on g.id = gi.group_id
+  where gi.invited_user_id = auth.uid()
+    and gi.status = 'pending'
+    and gi.expires_at > now()
+  order by gi.created_at desc;
+$$;
+
+revoke all on function get_pending_invites_for_me() from public;
+grant execute on function get_pending_invites_for_me() to authenticated;


### PR DESCRIPTION
## Summary
- add a new \\user_profiles\\ identity table with username uniqueness and RLS
- switch login to username-first by resolving \\username -> email\\ through an RPC
- add username onboarding route (\\/setup-username\\) and gate protected routes until profile exists
- move group invites to username/user-id targeting (existing accounts only)
- update register flow to collect username and create \\user_profiles\\ at signup

## Database
- new migration: \\20260425153000_user_profiles_and_username_invites.sql\\
- adds RPCs for username auth lookup and admin invite workflows
- replaces invite acceptance/pending RPC logic to use \\invited_user_id\\

## Validation
- npm run lint
- npm run build

Closes #105