### PR TITLE
feat: player-count filters for stats + leaderboard + highscores

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
 # Supabase
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Support
+# Preferred key
+VITE_SUPPORT_URL=https://ko-fi.com/talismantracker
+# Backward-compatible keys (optional)
+# VITE_KOFI_URL=https://ko-fi.com/talismantracker
+

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,6 +3,7 @@ import { Link, NavLink } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import GroupSwitcher from './GroupSwitcher'
 import PendingInvitesBanner from './PendingInvitesBanner'
+import { BUY_ME_A_COFFEE_COPY, BUY_ME_A_COFFEE_URL } from '../lib/supportLinks'
 
 const NAV_LINKS = [
   { to: '/', label: 'Home' },
@@ -153,9 +154,22 @@ export default function Layout({ children }) {
             <p className="text-muted text-sm font-body">
               Talisman Tracker — 4th Edition, All Expansions
             </p>
-            <p className="text-muted/50 text-xs font-body">
-              For the fellowship, by the fellowship
-            </p>
+            <div className="flex items-center gap-4">
+              <p className="text-muted/50 text-xs font-body">
+                For the fellowship, by the fellowship
+              </p>
+              {BUY_ME_A_COFFEE_URL && (
+                <a
+                  href={BUY_ME_A_COFFEE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full border border-gold-dim/20 px-3 py-1.5 text-xs font-heading tracking-wide text-gold/80 transition-colors hover:border-gold-dim/45 hover:text-gold"
+                >
+                  <span aria-hidden>☕</span>
+                  {BUY_ME_A_COFFEE_COPY.footerLabel}
+                </a>
+              )}
+            </div>
           </div>
         </div>
       </footer>

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
+import { matchesPlayerCountFilter } from '../lib/playerCountFilters'
 
 const CATEGORY_LABELS = {
   most_gold: 'Most Gold',
@@ -20,24 +21,35 @@ const DERIVED_CATEGORIES = {
   most_toad_times: 'total_toad_times',
 }
 
-export function useHighscoreRecords(groupId) {
+export function useHighscoreRecords(groupId, playerCountFilter = 'all') {
+  const emptyRecords = () => Object.keys(CATEGORY_LABELS).map((category) => ({
+    category,
+    label: CATEGORY_LABELS[category],
+    entries: [],
+  }))
+
   return useQuery({
-    queryKey: ['highscoreRecords', groupId ?? 'global'],
+    queryKey: ['highscoreRecords', groupId ?? 'global', playerCountFilter],
     queryFn: async () => {
       let gameIds = null
 
-      if (groupId) {
-        const { data: gamesData, error: gamesError } = await supabase
+      if (groupId || playerCountFilter !== 'all') {
+        let gamesQuery = supabase
           .from('games')
-          .select('id')
-          .eq('group_id', groupId)
+          .select('id, players:game_players ( id )')
+          .order('date', { ascending: false })
+
+        if (groupId) {
+          gamesQuery = gamesQuery.eq('group_id', groupId)
+        }
+
+        const { data: gamesData, error: gamesError } = await gamesQuery
         if (gamesError) throw gamesError
-        gameIds = gamesData.map(g => g.id)
-        if (gameIds.length === 0) return Object.keys(CATEGORY_LABELS).map((category) => ({
-          category,
-          label: CATEGORY_LABELS[category],
-          entries: [],
-        }))
+        const filteredGames = (gamesData ?? []).filter((game) =>
+          matchesPlayerCountFilter((game.players ?? []).length, playerCountFilter)
+        )
+        gameIds = filteredGames.map((g) => g.id)
+        if (gameIds.length === 0) return emptyRecords()
       }
 
       let hsQuery = supabase

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -1,20 +1,30 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../supabaseClient'
 import { computeLeaderboard } from '../lib/statsHelpers'
+import { matchesPlayerCountFilter } from '../lib/playerCountFilters'
 
-export function useLeaderboardStats(groupId) {
+export function useLeaderboardStats(groupId, playerCountFilter = 'all') {
   return useQuery({
-    queryKey: ['leaderboardStats', groupId ?? 'global'],
+    queryKey: ['leaderboardStats', groupId ?? 'global', playerCountFilter],
     queryFn: async () => {
       let gameIds = null
 
-      if (groupId) {
-        const { data: gamesData, error: gamesError } = await supabase
+      if (groupId || playerCountFilter !== 'all') {
+        let gamesQuery = supabase
           .from('games')
-          .select('id')
-          .eq('group_id', groupId)
+          .select('id, players:game_players ( id )')
+          .order('date', { ascending: false })
+
+        if (groupId) {
+          gamesQuery = gamesQuery.eq('group_id', groupId)
+        }
+
+        const { data: gamesData, error: gamesError } = await gamesQuery
         if (gamesError) throw gamesError
-        gameIds = gamesData.map(g => g.id)
+        const filteredGames = (gamesData ?? []).filter((game) =>
+          matchesPlayerCountFilter((game.players ?? []).length, playerCountFilter)
+        )
+        gameIds = filteredGames.map((g) => g.id)
         if (gameIds.length === 0) return []
       }
 

--- a/src/lib/playerCountFilters.js
+++ b/src/lib/playerCountFilters.js
@@ -1,0 +1,22 @@
+export const PLAYER_COUNT_FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: '2', label: '2P' },
+  { key: '3', label: '3P' },
+  { key: '4', label: '4P' },
+  { key: '5', label: '5P' },
+]
+
+export function matchesPlayerCountFilter(playerCount, filterKey) {
+  if (!filterKey || filterKey === 'all') return true
+  const target = Number(filterKey)
+  if (!Number.isFinite(target)) return true
+  return playerCount === target
+}
+
+export function filterGamesByPlayerCount(games, filterKey) {
+  if (!filterKey || filterKey === 'all') return games
+  return games.filter((game) => {
+    const count = Array.isArray(game.players) ? game.players.length : 0
+    return matchesPlayerCountFilter(count, filterKey)
+  })
+}

--- a/src/lib/statsAggregations.js
+++ b/src/lib/statsAggregations.js
@@ -202,6 +202,7 @@ export function computeEndingStats(games) {
         playerWins: 0,
         talismanWins: 0,
         totalDeaths: 0,
+        winningPlayerCounts: new Map(),
         winningCharCounts: new Map(),
         deathTypeCounts: new Map(),
       })
@@ -212,6 +213,12 @@ export function computeEndingStats(games) {
     if (winners.length > 0) {
       row.playerWins += 1
       for (const w of winners) {
+        if (w.player?.name) {
+          row.winningPlayerCounts.set(
+            w.player.name,
+            (row.winningPlayerCounts.get(w.player.name) ?? 0) + 1,
+          )
+        }
         if (w.winning_character) {
           row.winningCharCounts.set(
             w.winning_character,
@@ -234,6 +241,15 @@ export function computeEndingStats(games) {
   }
 
   return Array.from(stats.values()).map((row) => {
+    let topWinner = null
+    let topWinnerCount = 0
+    for (const [winner, count] of row.winningPlayerCounts.entries()) {
+      if (count > topWinnerCount) {
+        topWinner = winner
+        topWinnerCount = count
+      }
+    }
+
     let topChar = null
     let topCount = 0
     for (const [char, count] of row.winningCharCounts.entries()) {
@@ -260,7 +276,8 @@ export function computeEndingStats(games) {
       playerWinRate: row.times > 0 ? row.playerWins / row.times : 0,
       talismanWinRate: row.times > 0 ? row.talismanWins / row.times : 0,
       avgDeathsPerGame: row.times > 0 ? row.totalDeaths / row.times : 0,
-      topWinningCharacter: topChar ? `${topChar} (${topCount})` : 'NA',
+      topWinner: topWinner ? `${topWinner} (${topWinnerCount})` : 'NA',
+      topCharacter: topChar ? `${topChar} (${topCount})` : 'NA',
       topDeath: topDeathType ? `${topDeathType} (${topDeathCount})` : 'NA',
     }
   })

--- a/src/lib/supportLinks.js
+++ b/src/lib/supportLinks.js
@@ -1,0 +1,15 @@
+const configuredSupportUrl = (
+  import.meta.env.VITE_SUPPORT_URL ??
+  import.meta.env.VITE_KOFI_URL ??
+  import.meta.env.VITE_BUY_ME_A_COFFEE_URL ??
+  ''
+).trim()
+
+export const BUY_ME_A_COFFEE_URL = configuredSupportUrl || null
+
+export const BUY_ME_A_COFFEE_COPY = {
+  footerLabel: 'Support me',
+  homeTitle: 'Support Talisman Tracker',
+  homeBody: 'If you are enjoying the site, you can support me at Ko-fi. Any tips are appreciated!',
+  buttonLabel: 'Support on Ko-fi',
+}

--- a/src/pages/HighscoresBoard.jsx
+++ b/src/pages/HighscoresBoard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useHighscoreRecords } from '../hooks/useHighscoreRecords'
 import { useActiveGroup } from '../hooks/useActiveGroup'
 import ScopeToggle from '../components/ScopeToggle'
+import { PLAYER_COUNT_FILTERS } from '../lib/playerCountFilters'
 
 const CATEGORY_ICONS = {
   most_gold: (
@@ -81,14 +82,20 @@ const CATEGORY_ICONS = {
 export default function HighscoresBoard() {
   const { activeGroupId, activeGroup } = useActiveGroup()
   const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
+  const [playerCountFilter, setPlayerCountFilter] = useState('all')
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setScope(activeGroupId ? 'group' : 'global')
   }, [activeGroupId])
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPlayerCountFilter('all')
+  }, [scope])
+
   const groupId = scope === 'group' ? activeGroupId : null
-  const { data: records = [], isLoading, error } = useHighscoreRecords(groupId)
+  const { data: records = [], isLoading, error } = useHighscoreRecords(groupId, playerCountFilter)
   return (
     <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-8 animate-fade-up text-center">
@@ -98,6 +105,26 @@ export default function HighscoresBoard() {
         </div>
         <div className="mt-3 flex justify-center">
           <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
+        </div>
+        <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+          <span className="text-xs font-body text-muted uppercase tracking-wider mr-1">Players</span>
+          {PLAYER_COUNT_FILTERS.map((f) => {
+            const active = playerCountFilter === f.key
+            return (
+              <button
+                key={f.key}
+                type="button"
+                onClick={() => setPlayerCountFilter(f.key)}
+                className={`px-3 py-1.5 rounded-full text-xs font-body border transition-colors ${
+                  active
+                    ? 'border-gold bg-gold/10 text-gold'
+                    : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
+                }`}
+              >
+                {f.label}
+              </button>
+            )
+          })}
         </div>
         <p className="text-muted text-sm font-body mt-3">
           {scope === 'group' ? 'Per-game records within this group.' : 'All-time per-game records across all sessions.'}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { useGames } from '../hooks/useGames'
 import { useLeaderboardStats } from '../hooks/useLeaderboardStats'
+import { BUY_ME_A_COFFEE_COPY, BUY_ME_A_COFFEE_URL } from '../lib/supportLinks'
 
 function CornerFlourish({ position }) {
   const cornerClass = {
@@ -373,6 +374,33 @@ export default function Home() {
           ))}
         </div>
       </section>
+
+      {BUY_ME_A_COFFEE_URL && (
+        <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-10">
+          <div className="card-ornate bg-surface border border-gold-dim/15 rounded-xl p-6 sm:p-8">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-5">
+              <div>
+                <p className="text-gold/80 font-heading text-sm tracking-wider uppercase mb-2">Support</p>
+                <h2 className="font-heading text-2xl text-parchment tracking-wide mb-2">
+                  {BUY_ME_A_COFFEE_COPY.homeTitle}
+                </h2>
+                <p className="text-muted font-body max-w-2xl">
+                  {BUY_ME_A_COFFEE_COPY.homeBody}
+                </p>
+              </div>
+              <a
+                href={BUY_ME_A_COFFEE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-gold inline-flex items-center justify-center gap-2 shrink-0"
+              >
+                <span aria-hidden>☕</span>
+                {BUY_ME_A_COFFEE_COPY.buttonLabel}
+              </a>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* Recent activity teaser */}
       <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-20">

--- a/src/pages/Leaderboard.jsx
+++ b/src/pages/Leaderboard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useLeaderboardStats } from '../hooks/useLeaderboardStats'
 import { useActiveGroup } from '../hooks/useActiveGroup'
 import ScopeToggle from '../components/ScopeToggle'
+import { PLAYER_COUNT_FILTERS } from '../lib/playerCountFilters'
 
 const TALISMAN_SHOW = new Set(['name', 'games_played', 'wins', 'win_rate'])
 
@@ -35,6 +36,7 @@ function SortIcon({ active, direction }) {
 export default function Leaderboard() {
   const { activeGroupId, activeGroup } = useActiveGroup()
   const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
+  const [playerCountFilter, setPlayerCountFilter] = useState('all')
   const [sortKey, setSortKey] = useState('wins')
   const [sortDir, setSortDir] = useState('desc')
 
@@ -43,8 +45,13 @@ export default function Leaderboard() {
     setScope(activeGroupId ? 'group' : 'global')
   }, [activeGroupId])
 
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPlayerCountFilter('all')
+  }, [scope])
+
   const groupId = scope === 'group' ? activeGroupId : null
-  const { data: rows = [], error, isLoading } = useLeaderboardStats(groupId)
+  const { data: rows = [], error, isLoading } = useLeaderboardStats(groupId, playerCountFilter)
 
   const sorted = [...rows].sort((a, b) => {
     const aVal = a[sortKey]
@@ -71,6 +78,26 @@ export default function Leaderboard() {
         </div>
         <div className="mt-3 flex justify-center">
           <ScopeToggle value={scope} onChange={setScope} groupName={activeGroup?.name ?? null} />
+        </div>
+        <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+          <span className="text-xs font-body text-muted uppercase tracking-wider mr-1">Players</span>
+          {PLAYER_COUNT_FILTERS.map((f) => {
+            const active = playerCountFilter === f.key
+            return (
+              <button
+                key={f.key}
+                type="button"
+                onClick={() => setPlayerCountFilter(f.key)}
+                className={`px-3 py-1.5 rounded-full text-xs font-body border transition-colors ${
+                  active
+                    ? 'border-gold bg-gold/10 text-gold'
+                    : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
+                }`}
+              >
+                {f.label}
+              </button>
+            )
+          })}
         </div>
         <p className="text-muted text-sm font-body mt-3">Click any column to sort.</p>
       </div>

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -5,6 +5,10 @@ import { useCharacters } from '../hooks/useCharacters'
 import { useActiveGroup } from '../hooks/useActiveGroup'
 import ScopeToggle from '../components/ScopeToggle'
 import {
+  PLAYER_COUNT_FILTERS,
+  filterGamesByPlayerCount,
+} from '../lib/playerCountFilters'
+import {
   OPTIONAL_EXPANSION_FILTERS,
   filterGamesByOptionalExpansions,
   computeCharacterStats,
@@ -32,7 +36,7 @@ function SortIcon({ active, direction }) {
   )
 }
 
-function useSort(initialKey, initialDir = 'desc') {
+function useSort(initialKey, initialDir = 'desc', tieBreakers = {}) {
   const [sortKey, setSortKey] = useState(initialKey)
   const [sortDir, setSortDir] = useState(initialDir)
   const toggle = (key) => {
@@ -42,8 +46,22 @@ function useSort(initialKey, initialDir = 'desc') {
   const sort = (rows) => [...rows].sort((a, b) => {
     const aVal = a[sortKey]
     const bVal = b[sortKey]
-    if (typeof aVal === 'string') return sortDir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal)
-    return sortDir === 'asc' ? (aVal ?? 0) - (bVal ?? 0) : (bVal ?? 0) - (aVal ?? 0)
+    const primary = typeof aVal === 'string'
+      ? (sortDir === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal))
+      : (sortDir === 'asc' ? (aVal ?? 0) - (bVal ?? 0) : (bVal ?? 0) - (aVal ?? 0))
+    if (primary !== 0) return primary
+
+    const configuredTieBreakers = tieBreakers[sortKey] ?? []
+    for (const rule of configuredTieBreakers) {
+      const aTie = a[rule.key]
+      const bTie = b[rule.key]
+      const tieCompare = typeof aTie === 'string'
+        ? ((rule.dir ?? 'desc') === 'asc' ? (aTie ?? '').localeCompare(bTie ?? '') : (bTie ?? '').localeCompare(aTie ?? ''))
+        : ((rule.dir ?? 'desc') === 'asc' ? (aTie ?? 0) - (bTie ?? 0) : (bTie ?? 0) - (aTie ?? 0))
+      if (tieCompare !== 0) return tieCompare
+    }
+
+    return 0
   })
   return { sortKey, sortDir, toggle, sort }
 }
@@ -95,7 +113,9 @@ function CharactersTab({ games, allCharacters }) {
   const [expansionFilter, setExpansionFilter] = useState('all')
   const [selectedPlayer, setSelectedPlayer] = useState('')
   const { sortKey, sortDir, toggle, sort } = useSort('games', 'desc')
-  const playerSort = useSort('games', 'desc')
+  const playerSort = useSort('games', 'desc', {
+    games: [{ key: 'wins', dir: 'desc' }],
+  })
 
   const rows = useMemo(
     () => computeCharacterStats(games, allCharacters),
@@ -213,7 +233,8 @@ function EndingsTab({ games }) {
     { key: 'playerWinRate', label: 'Player Win %', align: 'center', format: pct, accent: true },
     { key: 'talismanWinRate', label: 'Talisman Win %', align: 'center', format: pct },
     { key: 'avgDeathsPerGame', label: 'Avg Deaths / Game', align: 'center', format: v => v.toFixed(2) },
-    { key: 'topWinningCharacter', label: 'Top Winner', align: 'left', sortable: false },
+    { key: 'topWinner', label: 'Top Winner', align: 'left', sortable: false },
+    { key: 'topCharacter', label: 'Top Character', align: 'left', sortable: false },
     { key: 'topDeath', label: 'Top Death', align: 'left', sortable: false },
   ]
 
@@ -606,6 +627,7 @@ function DeathsTab({ games }) {
 export default function Stats() {
   const [tab, setTab] = useState('characters')
   const [optionalFilter, setOptionalFilter] = useState('all')
+  const [playerCountFilter, setPlayerCountFilter] = useState('all')
   const { activeGroupId, activeGroup } = useActiveGroup()
   const [scope, setScope] = useState(() => activeGroupId ? 'group' : 'global')
 
@@ -617,6 +639,7 @@ export default function Stats() {
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setOptionalFilter('all')
+    setPlayerCountFilter('all')
   }, [scope])
 
   const groupId = scope === 'group' ? activeGroupId : null
@@ -624,8 +647,11 @@ export default function Stats() {
   const { data: allCharacters = [] } = useCharacters()
 
   const games = useMemo(
-    () => filterGamesByOptionalExpansions(rawGames, optionalFilter),
-    [rawGames, optionalFilter],
+    () => {
+      const byOptionalExpansion = filterGamesByOptionalExpansions(rawGames, optionalFilter)
+      return filterGamesByPlayerCount(byOptionalExpansion, playerCountFilter)
+    },
+    [rawGames, optionalFilter, playerCountFilter],
   )
 
   return (
@@ -666,6 +692,28 @@ export default function Stats() {
         <span className="ml-auto text-xs font-body text-muted">
           {games.length} game{games.length !== 1 ? 's' : ''}
         </span>
+      </div>
+
+      {/* Player-count filter */}
+      <div className="mb-6 flex flex-wrap items-center gap-2 animate-fade-up delay-1">
+        <span className="text-xs font-body text-muted uppercase tracking-wider mr-1">Players</span>
+        {PLAYER_COUNT_FILTERS.map((f) => {
+          const active = playerCountFilter === f.key
+          return (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setPlayerCountFilter(f.key)}
+              className={`px-3 py-1.5 rounded-full text-xs font-body border transition-colors ${
+                active
+                  ? 'border-gold bg-gold/10 text-gold'
+                  : 'border-gold-dim/20 text-muted hover:border-gold-dim/40'
+              }`}
+            >
+              {f.label}
+            </button>
+          )
+        })}
       </div>
 
       {/* Tab nav */}


### PR DESCRIPTION
## Summary
- add player-count filters (All, 2P, 3P, 4P, 5P) to Stats, Leaderboard, and Highscores
- reset player-count filters to All when scope changes between Group/Global
- update Endings stats to include Top Winner (player) and rename prior winner metric to Top Character
- add support CTA integration in footer and home with shared config
- switch support copy to Ko-fi and add generic env support key with backward-compatible fallbacks

## Validation
- npm run lint

Closes #112