### PR TITLE
feat: average tierlist + platform-wide global scope (issue #62)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import HouseRules from './pages/HouseRules'
 import HouseRulesContent from './pages/HouseRulesContent'
 import Rulebooks from './pages/Rulebooks'
 import Tierlist from './pages/Tierlist'
+import AverageTierlist from './pages/AverageTierlist'
 
 const queryClient = new QueryClient()
 
@@ -62,6 +63,7 @@ export default function App() {
               <Route path="/games/:id" element={<GameDetail />} />
               <Route path="/players" element={<Players />} />
               <Route path="/players/:id/tierlist" element={<Tierlist />} />
+              <Route path="/tierlists/average" element={<AverageTierlist />} />
               <Route path="/stats" element={<Stats />} />
               <Route path="/counters" element={<Counters />} />
               <Route path="/house-rules" element={<HouseRules />} />

--- a/src/hooks/useAverageTierlist.js
+++ b/src/hooks/useAverageTierlist.js
@@ -1,0 +1,141 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../supabaseClient'
+
+const TIERS = ['S', 'A', 'B', 'C', 'D', 'F']
+const TIER_POINTS = { S: 6, A: 5, B: 4, C: 3, D: 2, F: 1 }
+const POINT_TO_TIER = { 6: 'S', 5: 'A', 4: 'B', 3: 'C', 2: 'D', 1: 'F' }
+
+const EMPTY_TIERS = { S: [], A: [], B: [], C: [], D: [], F: [] }
+
+function keyFingerprint(ids) {
+  return [...ids].sort().join(',')
+}
+
+function clampPoint(value) {
+  if (value < 1) return 1
+  if (value > 6) return 6
+  return value
+}
+
+function buildGroupedStats(statsSource) {
+  const grouped = { S: [], A: [], B: [], C: [], D: [], F: [] }
+  const statsByKey = {}
+
+  for (const [key, raw] of Object.entries(statsSource ?? {})) {
+    if (!key || !raw) continue
+
+    const average = Number(raw.average ?? 0)
+    const count = Number(raw.count ?? 0)
+    const total = Number(raw.total ?? average * count)
+    if (!Number.isFinite(average) || !Number.isFinite(count) || count <= 0) continue
+
+    const nearestPoint = clampPoint(Math.round(average))
+    const assignedTier = POINT_TO_TIER[nearestPoint]
+    statsByKey[key] = { average, count, total, tier: assignedTier }
+    grouped[assignedTier].push(key)
+  }
+
+  for (const tier of TIERS) {
+    grouped[tier].sort((left, right) => {
+      const leftStats = statsByKey[left]
+      const rightStats = statsByKey[right]
+      if (!leftStats || !rightStats) return 0
+      if (rightStats.average !== leftStats.average) return rightStats.average - leftStats.average
+      if (rightStats.count !== leftStats.count) return rightStats.count - leftStats.count
+      return left.localeCompare(right)
+    })
+  }
+
+  return { tiers: grouped, statsByKey }
+}
+
+export function useAverageTierlist({
+  listType = 'character',
+  scope = 'group',
+  groupPlayerIds = [],
+  enabled = true,
+} = {}) {
+  return useQuery({
+    queryKey: ['averageTierlist', listType, scope, keyFingerprint(groupPlayerIds)],
+    enabled,
+    queryFn: async () => {
+      if (scope === 'group' && groupPlayerIds.length === 0) {
+        return {
+          tiers: EMPTY_TIERS,
+          statsByKey: {},
+          playerCount: 0,
+          submittedCount: 0,
+        }
+      }
+
+      if (scope === 'global') {
+        const { data, error } = await supabase.rpc('get_platform_average_tierlist', {
+          p_list_type: listType,
+        })
+        if (error) throw error
+
+        const payload = data ?? {}
+        const { tiers, statsByKey } = buildGroupedStats(payload.stats_by_key ?? {})
+
+        return {
+          tiers,
+          statsByKey,
+          playerCount: Number(payload.player_count ?? 0),
+          submittedCount: Number(payload.submitted_count ?? 0),
+        }
+      }
+
+      let query = supabase
+        .from('tierlists')
+        .select('player_id, tiers')
+        .eq('list_type', listType)
+        .in('player_id', groupPlayerIds)
+
+      const { data, error } = await query
+
+      if (error) throw error
+
+      const totalsByKey = new Map()
+      const countsByKey = new Map()
+      const submittedPlayers = new Set()
+
+      for (const row of data ?? []) {
+        submittedPlayers.add(row.player_id)
+
+        const tiers = row.tiers ?? {}
+        const seen = new Set()
+
+        for (const tier of TIERS) {
+          const keys = Array.isArray(tiers[tier]) ? tiers[tier] : []
+          const points = TIER_POINTS[tier]
+
+          for (const key of keys) {
+            if (!key || seen.has(key)) continue
+            seen.add(key)
+            totalsByKey.set(key, (totalsByKey.get(key) ?? 0) + points)
+            countsByKey.set(key, (countsByKey.get(key) ?? 0) + 1)
+          }
+        }
+      }
+
+      const rawStats = {}
+      for (const [key, total] of totalsByKey.entries()) {
+        const count = Number(countsByKey.get(key) ?? 0)
+        if (count <= 0) continue
+        rawStats[key] = {
+          average: total / count,
+          count,
+          total,
+        }
+      }
+      const { tiers, statsByKey } = buildGroupedStats(rawStats)
+
+      return {
+        tiers,
+        statsByKey,
+        playerCount: groupPlayerIds.length,
+        submittedCount: submittedPlayers.size,
+      }
+    },
+  })
+}

--- a/src/hooks/useEncounterScores.js
+++ b/src/hooks/useEncounterScores.js
@@ -6,6 +6,18 @@ export function useEncounterScores(groupId) {
   return useQuery({
     queryKey: ['encounterScores', groupId ?? 'global'],
     queryFn: async () => {
+      if (!groupId) {
+        const { data, error } = await supabase.rpc('get_platform_encounter_totals')
+        if (error) throw error
+        return (data ?? []).map((row) => ({
+          id: `global-${row.encounter_name}`,
+          encounterName: row.encounter_name,
+          creatureWins: Number(row.creature_wins ?? 0),
+          playerWins: Number(row.player_wins ?? 0),
+          groupId: null,
+        }))
+      }
+
       let query = supabase
         .from('encounter_scores')
         .select('id, encounter_name, creature_wins, player_wins, group_id')
@@ -23,7 +35,7 @@ export function useEncounterScores(groupId) {
         groupId: row.group_id,
       }))
 
-      return groupId ? rows : aggregateEncounterScores(rows)
+      return aggregateEncounterScores(rows)
     },
   })
 }

--- a/src/hooks/useHighscoreRecords.js
+++ b/src/hooks/useHighscoreRecords.js
@@ -31,6 +31,65 @@ export function useHighscoreRecords(groupId, playerCountFilter = 'all') {
   return useQuery({
     queryKey: ['highscoreRecords', groupId ?? 'global', playerCountFilter],
     queryFn: async () => {
+      if (!groupId) {
+        const { data, error } = await supabase.rpc('get_platform_highscore_payload', {
+          p_player_count_filter: playerCountFilter,
+        })
+        if (error) throw error
+
+        const payload = data ?? {}
+        const hsRows = payload.highscores ?? []
+        const gpRows = payload.game_players ?? []
+        const deathRows = payload.deaths ?? []
+
+        const deathCounts = new Map()
+        for (const d of deathRows) {
+          const key = `${d.game_id}::${d.player_id}`
+          deathCounts.set(key, (deathCounts.get(key) ?? 0) + 1)
+        }
+
+        const gpWithDeaths = gpRows.map(gp => ({
+          ...gp,
+          total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
+        }))
+
+        const topByCategory = new Map()
+        for (const row of hsRows) {
+          if (!topByCategory.has(row.category)) topByCategory.set(row.category, [])
+          topByCategory.get(row.category).push(row)
+        }
+
+        for (const [category, column] of Object.entries(DERIVED_CATEGORIES)) {
+          const rows = []
+          for (const gp of gpWithDeaths) {
+            const value = Number(gp[column] ?? 0)
+            if (value <= 0) continue
+            rows.push({ category, value, player: gp.player, game: gp.game })
+          }
+          topByCategory.set(category, rows)
+        }
+
+        for (const [category, rows] of topByCategory) {
+          rows.sort((a, b) => Number(b.value) - Number(a.value))
+          topByCategory.set(category, rows.slice(0, 5))
+        }
+
+        return Object.keys(CATEGORY_LABELS).map((category) => {
+          const rows = topByCategory.get(category) ?? []
+          return {
+            category,
+            label: CATEGORY_LABELS[category],
+            entries: rows.map((row, _i, arr) => ({
+              rank: arr.findIndex((r) => Number(r.value) === Number(row.value)) + 1,
+              player: row.player?.name ?? null,
+              value: row.value,
+              game_date: row.game?.date ?? null,
+              game_id: row.game?.id ?? null,
+            })),
+          }
+        })
+      }
+
       let gameIds = null
 
       if (groupId || playerCountFilter !== 'all') {

--- a/src/hooks/useLeaderboardStats.js
+++ b/src/hooks/useLeaderboardStats.js
@@ -7,6 +7,37 @@ export function useLeaderboardStats(groupId, playerCountFilter = 'all') {
   return useQuery({
     queryKey: ['leaderboardStats', groupId ?? 'global', playerCountFilter],
     queryFn: async () => {
+      if (!groupId) {
+        const { data, error } = await supabase.rpc('get_platform_leaderboard_payload', {
+          p_player_count_filter: playerCountFilter,
+        })
+        if (error) throw error
+
+        const payload = data ?? {}
+        const gpRows = payload.game_players ?? []
+        const deathRows = payload.deaths ?? []
+
+        const deathCounts = new Map()
+        const deathTypesByPlayer = new Map()
+        for (const d of deathRows) {
+          const key = `${d.game_id}::${d.player_id}`
+          deathCounts.set(key, (deathCounts.get(key) ?? 0) + 1)
+
+          const typeName = d.death_type?.name
+          if (typeName) {
+            const counts = deathTypesByPlayer.get(d.player_id) ?? new Map()
+            counts.set(typeName, (counts.get(typeName) ?? 0) + 1)
+            deathTypesByPlayer.set(d.player_id, counts)
+          }
+        }
+
+        const normalizedGp = gpRows.map((gp) => ({
+          ...gp,
+          total_deaths: deathCounts.get(`${gp.game_id}::${gp.player?.id}`) ?? 0,
+        }))
+        return computeLeaderboard(normalizedGp, deathTypesByPlayer, deathRows)
+      }
+
       let gameIds = null
 
       if (groupId || playerCountFilter !== 'all') {

--- a/src/hooks/useStatsData.js
+++ b/src/hooks/useStatsData.js
@@ -5,6 +5,22 @@ export function useStatsData(groupId) {
   return useQuery({
     queryKey: ['stats', groupId ?? 'global'],
     queryFn: async () => {
+      if (!groupId) {
+        const { data, error } = await supabase.rpc('get_platform_stats_games')
+        if (error) throw error
+        return (data ?? []).map(game => {
+          const allDeaths = game.deaths ?? []
+          return {
+            ...game,
+            players: (game.players ?? []).map(gp => ({
+              ...gp,
+              total_deaths: allDeaths.filter(d => d.player_id === gp.player.id).length,
+              deaths: allDeaths.filter(d => d.player_id === gp.player.id),
+            })),
+          }
+        })
+      }
+
       let query = supabase
         .from('games')
         .select(`

--- a/src/pages/AverageTierlist.jsx
+++ b/src/pages/AverageTierlist.jsx
@@ -1,0 +1,375 @@
+import { useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { useAverageTierlist } from '../hooks/useAverageTierlist'
+import { useIcons } from '../hooks/useIcons'
+import { usePets } from '../hooks/usePets'
+import { useActiveGroup } from '../hooks/useActiveGroup'
+import { usePlayers } from '../hooks/usePlayers'
+import ScopeToggle from '../components/ScopeToggle'
+import { AVAILABLE_ICONS } from '../data/availableIcons'
+
+const iconExtMap = new Map(AVAILABLE_ICONS.map((icon) => [icon.key, icon.ext]))
+const TIERS = ['S', 'A', 'B', 'C', 'D', 'F']
+const EMPTY_TIERS = { S: [], A: [], B: [], C: [], D: [], F: [] }
+
+const TIER_STYLES = {
+  S: { label: 'bg-red-900/60 text-red-100 border-red-700/60', row: 'border-red-900/40 bg-red-950/20' },
+  A: { label: 'bg-orange-900/60 text-orange-100 border-orange-700/60', row: 'border-orange-900/40 bg-orange-950/20' },
+  B: { label: 'bg-yellow-900/60 text-yellow-100 border-yellow-700/60', row: 'border-yellow-900/40 bg-yellow-950/20' },
+  C: { label: 'bg-emerald-900/60 text-emerald-100 border-emerald-700/60', row: 'border-emerald-900/40 bg-emerald-950/20' },
+  D: { label: 'bg-blue-900/60 text-blue-100 border-blue-700/60', row: 'border-blue-900/40 bg-blue-950/20' },
+  F: { label: 'bg-purple-900/60 text-purple-100 border-purple-700/60', row: 'border-purple-900/40 bg-purple-950/20' },
+}
+
+const EXPANSION_LABELS = {
+  base: 'Base Game',
+  reaper: 'The Reaper',
+  dungeon: 'The Dungeon',
+  highland: 'The Highland',
+  sacred_pool: 'The Sacred Pool',
+  harbinger: 'The Harbinger',
+  frostmarch: 'The Frostmarch',
+  blood_moon: 'The Blood Moon',
+  city: 'The City',
+  woodland: 'The Woodland',
+  dragon: 'The Dragon',
+  firelands: 'The Firelands',
+  cataclysm: 'The Cataclysm',
+}
+
+function tabToListType(tab) {
+  return tab === 'pets' ? 'pet' : 'character'
+}
+
+function listTypeToTab(listType) {
+  return listType === 'pet' ? 'pets' : 'characters'
+}
+
+function tileSrcFor(item, listType) {
+  if (listType === 'pet') return `/pets/${item.key}.png`
+  return `/icons/${item.key}${iconExtMap.get(item.key) ?? '.png'}`
+}
+
+function detailSrcFor(item, listType) {
+  if (listType === 'pet') return `/pets/${item.key}.png`
+  return `/characters/${item.key}.webp`
+}
+
+function EntityImage({ src, name, className, fallbackTextSize = 'text-xs' }) {
+  const [errored, setErrored] = useState(false)
+  if (errored) {
+    return (
+      <div className={`${className} flex items-center justify-center bg-deep`}>
+        <span className={`font-heading text-gold-dim ${fallbackTextSize} text-center px-1`}>
+          {name}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <img
+      src={src}
+      alt={name}
+      className={className}
+      onError={() => setErrored(true)}
+    />
+  )
+}
+
+function EntityTile({ item, listType, onHover, isActive }) {
+  const isPet = listType === 'pet'
+  const tileFrameClass = isPet ? 'w-12 h-16 rounded-md' : 'w-14 h-14 rounded-lg'
+  const tileImageClass = isPet
+    ? 'w-full h-full object-contain pointer-events-none p-0.5 bg-surface'
+    : 'w-full h-full object-cover pointer-events-none'
+
+  return (
+    <div
+      onMouseEnter={() => onHover(item.key)}
+      onFocus={() => onHover(item.key)}
+      tabIndex={0}
+      className={`${tileFrameClass} overflow-hidden border bg-deep transition-colors ${
+        isActive ? 'border-gold ring-1 ring-gold/40' : 'border-gold-dim/30 hover:border-gold/60'
+      }`}
+      title={item.name}
+    >
+      <EntityImage
+        key={item.key}
+        src={tileSrcFor(item, listType)}
+        name={item.name}
+        className={tileImageClass}
+      />
+    </div>
+  )
+}
+
+function DetailPanel({ item, listType, stats }) {
+  const isPet = listType === 'pet'
+  const detailFrameClass = isPet
+    ? 'w-full max-w-sm aspect-[5/7] rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70'
+    : 'w-full max-w-lg aspect-[3/2] rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70'
+
+  if (!item) {
+    return (
+      <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 flex items-center justify-center min-h-28">
+        <p className="text-muted text-sm font-body italic">Hover an entry to preview details.</p>
+      </div>
+    )
+  }
+
+  function PetDetailArtwork() {
+    const [failed, setFailed] = useState(false)
+    if (failed) {
+      return (
+        <div className="w-full h-full p-6 flex flex-col items-center justify-center gap-3 text-center">
+          <p className="font-heading text-lg text-gold-light">{item.name}</p>
+          <p className="text-sm font-body text-parchment/80">
+            {item.ability_text ?? 'Image coming soon.'}
+          </p>
+        </div>
+      )
+    }
+    return (
+      <img
+        src={detailSrcFor(item, listType)}
+        alt={item.name}
+        className="w-full h-full object-contain p-1 bg-surface"
+        onError={() => setFailed(true)}
+      />
+    )
+  }
+
+  return (
+    <div className="bg-surface border border-gold-dim/20 rounded-xl p-6 flex flex-col items-center gap-4">
+      <div className="text-center">
+        <p className="text-xs font-body text-gold-dim uppercase tracking-widest mb-1">
+          {EXPANSION_LABELS[item.expansion] ?? item.expansion ?? ''}
+        </p>
+        <h3 className="font-heading text-2xl text-parchment tracking-wide">{item.name}</h3>
+      </div>
+      <div className={detailFrameClass}>
+        {listType === 'pet' ? (
+          <PetDetailArtwork key={item.key} />
+        ) : (
+          <EntityImage
+            src={detailSrcFor(item, listType)}
+            name={item.name}
+            className="w-full h-full object-cover"
+            fallbackTextSize="text-base"
+          />
+        )}
+      </div>
+      {stats && (
+        <p className="text-sm font-body text-gold-dim text-center">
+          Average score: {stats.average.toFixed(2)} ({stats.count} ranked)
+        </p>
+      )}
+      {listType === 'pet' && item.ability_text && (
+        <p className="text-sm font-body text-parchment/80 text-center max-w-lg">
+          {item.ability_text}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default function AverageTierlist() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { activeGroupId, activeGroup } = useActiveGroup()
+  const playersQuery = usePlayers()
+  const [scope, setScope] = useState(() => (activeGroupId ? 'group' : 'global'))
+  const effectiveScope = scope === 'group' && activeGroupId ? 'group' : 'global'
+
+  const listType = tabToListType(searchParams.get('tab'))
+  const groupPlayerIds = useMemo(
+    () => ((effectiveScope === 'group' && activeGroupId) ? (playersQuery.data ?? []).map((player) => player.id) : []),
+    [effectiveScope, activeGroupId, playersQuery.data],
+  )
+  const averageQuery = useAverageTierlist({
+    listType,
+    scope: effectiveScope,
+    groupPlayerIds,
+    enabled: effectiveScope === 'group' ? Boolean(activeGroupId) && playersQuery.isSuccess : true,
+  })
+  const iconsQuery = useIcons()
+  const petsQuery = usePets()
+
+  const sourceItems = useMemo(() => {
+    if (listType === 'pet') return petsQuery.data ?? []
+    return (iconsQuery.data ?? []).filter((icon) => icon.key !== 'toad')
+  }, [listType, iconsQuery.data, petsQuery.data])
+
+  const itemsByKey = useMemo(() => {
+    const map = new Map()
+    for (const item of sourceItems) map.set(item.key, item)
+    return map
+  }, [sourceItems])
+
+  const statsByKey = averageQuery.data?.statsByKey ?? {}
+  const tiers = averageQuery.data?.tiers ?? EMPTY_TIERS
+
+  const rankedKeys = useMemo(() => {
+    const set = new Set()
+    for (const tier of TIERS) {
+      for (const key of tiers[tier] ?? []) set.add(key)
+    }
+    return set
+  }, [tiers])
+
+  const unranked = useMemo(
+    () => sourceItems.filter((item) => !rankedKeys.has(item.key)),
+    [sourceItems, rankedKeys],
+  )
+
+  const [previewKey, setPreviewKey] = useState(null)
+  const firstRankedKey = TIERS.flatMap((tier) => tiers[tier] ?? [])[0] ?? unranked[0]?.key ?? null
+  const activePreviewKey = previewKey ?? firstRankedKey
+  const previewItem = activePreviewKey ? itemsByKey.get(activePreviewKey) ?? null : null
+
+  const handleTabSwitch = (nextType) => {
+    if (nextType === listType) return
+    setPreviewKey(null)
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.set('tab', listTypeToTab(nextType))
+      return next
+    })
+  }
+
+  const sourceError = listType === 'pet' ? petsQuery.error : iconsQuery.error
+  const error = averageQuery.error || sourceError || playersQuery.error
+  const isLoading =
+    (effectiveScope === 'group' && playersQuery.isLoading) ||
+    averageQuery.isLoading ||
+    (listType === 'pet' ? petsQuery.isLoading : iconsQuery.isLoading)
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="mb-6 animate-fade-up">
+        <Link to="/players" className="text-gold-dim hover:text-gold text-sm font-body transition-colors mb-3 inline-block">
+          Back to Players
+        </Link>
+
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="font-heading text-3xl text-parchment tracking-wide">Average Tierlist</h1>
+            <p className="text-muted text-sm font-body mt-1">
+              {effectiveScope === 'group'
+                ? `Group: ${activeGroup?.name ?? 'Select a group'}`
+                : 'Global scope across every player on the platform (all groups combined).'}
+            </p>
+          </div>
+          <div className="text-xs font-body text-muted space-y-1">
+            <p>Players in scope: {averageQuery.data?.playerCount ?? 0}</p>
+            <p>Submitted list count: {averageQuery.data?.submittedCount ?? 0}</p>
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <ScopeToggle value={effectiveScope} onChange={setScope} groupName={activeGroup?.name ?? null} />
+        </div>
+
+        <p className="text-muted text-sm font-body mt-3">
+          Unranked entries are excluded from averages and stay in the unranked pool.
+        </p>
+
+        <div className="mt-4 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handleTabSwitch('character')}
+            className={`px-3 py-1.5 rounded-md text-xs font-body tracking-wide border transition-colors ${
+              listType === 'character'
+                ? 'bg-gold/20 border-gold/60 text-gold-light'
+                : 'bg-surface border-gold-dim/30 text-muted hover:text-gold hover:border-gold/40'
+            }`}
+          >
+            Characters
+          </button>
+          <button
+            type="button"
+            onClick={() => handleTabSwitch('pet')}
+            className={`px-3 py-1.5 rounded-md text-xs font-body tracking-wide border transition-colors ${
+              listType === 'pet'
+                ? 'bg-gold/20 border-gold/60 text-gold-light'
+                : 'bg-surface border-gold-dim/30 text-muted hover:text-gold hover:border-gold/40'
+            }`}
+          >
+            Pets
+          </button>
+        </div>
+
+        <div className="ornament-divider mt-4">
+          <span className="text-gold-dim">&#9670;</span>
+        </div>
+      </div>
+
+      {error && <p className="text-danger text-sm font-body mb-4">{error.message}</p>}
+
+      {isLoading ? (
+        <p className="text-muted text-sm font-body italic">Loading...</p>
+      ) : (
+        <div className="space-y-3 animate-fade-up delay-1">
+          {TIERS.map((tier) => {
+            const style = TIER_STYLES[tier]
+            const keys = tiers[tier] ?? []
+
+            return (
+              <div key={tier} className={`flex items-stretch border rounded-lg overflow-hidden ${style.row}`}>
+                <div className={`flex items-center justify-center w-16 font-display text-3xl tracking-wider border-r ${style.label}`}>
+                  {tier}
+                </div>
+                <div className="flex-1 min-h-[72px] p-2 flex flex-wrap gap-2 items-start">
+                  {keys.length === 0 ? (
+                    <span className="text-muted/60 text-xs font-body italic self-center px-2">No ranked entries in this tier.</span>
+                  ) : (
+                    keys.map((key) => {
+                      const item = itemsByKey.get(key)
+                      if (!item) return null
+                      return (
+                        <EntityTile
+                          key={key}
+                          item={item}
+                          listType={listType}
+                          onHover={setPreviewKey}
+                          isActive={key === activePreviewKey}
+                        />
+                      )
+                    })
+                  )}
+                </div>
+              </div>
+            )
+          })}
+
+          <DetailPanel
+            item={previewItem}
+            listType={listType}
+            stats={previewItem ? (statsByKey[previewItem.key] ?? null) : null}
+          />
+
+          <div className="bg-surface border border-gold-dim/20 rounded-xl p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h2 className="font-heading text-lg text-parchment tracking-wide">Unranked Pool</h2>
+              <span className="text-xs font-body text-muted">{unranked.length} entries</span>
+            </div>
+            <div className="flex flex-wrap gap-2 min-h-[72px]">
+              {unranked.length === 0 ? (
+                <p className="text-muted text-sm font-body italic">Every entry has at least one ranking.</p>
+              ) : (
+                unranked.map((item) => (
+                  <EntityTile
+                    key={item.key}
+                    item={item}
+                    listType={listType}
+                    onHover={setPreviewKey}
+                    isActive={item.key === activePreviewKey}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Counters.jsx
+++ b/src/pages/Counters.jsx
@@ -118,11 +118,11 @@ export default function Counters() {
 
   if (scope === 'group' && !activeGroupId) {
     return (
-      <GroupRequiredState
-        title="Select a group to update encounter counters"
-        body="Global view shows the combined totals across your groups. Pick an active group when you want to edit its counters."
-      />
-    )
+        <GroupRequiredState
+          title="Select a group to update encounter counters"
+          body="Global view shows the combined totals across the full platform. Pick an active group when you want to edit its counters."
+        />
+      )
   }
 
   return (

--- a/src/pages/Players.jsx
+++ b/src/pages/Players.jsx
@@ -200,15 +200,23 @@ export default function Players() {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-8 animate-fade-up">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
           <h1 className="font-heading text-3xl text-parchment tracking-wide">Players</h1>
-          <button
-            onClick={openAddModal}
-            className="btn-gold text-sm"
-            title={!activeGroupId ? 'Select an active group to add guest players' : undefined}
-          >
-            Add Player
-          </button>
+          <div className="flex items-center gap-2">
+            <Link
+              to="/tierlists/average"
+              className="btn-outline text-sm"
+            >
+              Average Tierlist
+            </Link>
+            <button
+              onClick={openAddModal}
+              className="btn-gold text-sm"
+              title={!activeGroupId ? 'Select an active group to add guest players' : undefined}
+            >
+              Add Player
+            </button>
+          </div>
         </div>
         <div className="ornament-divider mt-3">
           <span className="text-gold-dim">&#9670;</span>

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -112,10 +112,17 @@ const pct = (v) => `${(v * 100).toFixed(1)}%`
 function CharactersTab({ games, allCharacters }) {
   const [expansionFilter, setExpansionFilter] = useState('all')
   const [selectedPlayer, setSelectedPlayer] = useState('')
-  const { sortKey, sortDir, toggle, sort } = useSort('games', 'desc')
-  const playerSort = useSort('games', 'desc', {
+  const characterTieBreakers = {
+    character: [{ key: 'wins', dir: 'desc' }, { key: 'games', dir: 'desc' }],
+    expansion: [{ key: 'wins', dir: 'desc' }, { key: 'games', dir: 'desc' }],
     games: [{ key: 'wins', dir: 'desc' }],
-  })
+    wins: [{ key: 'games', dir: 'desc' }],
+    winRate: [{ key: 'wins', dir: 'desc' }, { key: 'games', dir: 'desc' }],
+    deaths: [{ key: 'wins', dir: 'desc' }, { key: 'games', dir: 'desc' }],
+    deathRate: [{ key: 'wins', dir: 'desc' }, { key: 'games', dir: 'desc' }],
+  }
+  const { sortKey, sortDir, toggle, sort } = useSort('games', 'desc', characterTieBreakers)
+  const playerSort = useSort('games', 'desc', characterTieBreakers)
 
   const rows = useMemo(
     () => computeCharacterStats(games, allCharacters),

--- a/supabase/migrations/20260428170000_platform_average_tierlist.sql
+++ b/supabase/migrations/20260428170000_platform_average_tierlist.sql
@@ -1,0 +1,112 @@
+create or replace function public.get_platform_average_tierlist(p_list_type text default 'character')
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_row record;
+  v_tier text;
+  v_key text;
+  v_points integer;
+  v_totals jsonb := '{}'::jsonb;
+  v_counts jsonb := '{}'::jsonb;
+  v_stats jsonb := '{}'::jsonb;
+  v_seen text[];
+  v_total numeric;
+  v_count integer;
+  v_player_count integer := 0;
+  v_submitted_count integer := 0;
+begin
+  if p_list_type not in ('character', 'pet') then
+    raise exception 'Invalid list_type: %', p_list_type using errcode = '22023';
+  end if;
+
+  select count(*) into v_player_count from players;
+
+  select count(distinct player_id)
+    into v_submitted_count
+  from tierlists
+  where list_type = p_list_type;
+
+  for v_row in
+    select player_id, tiers
+    from tierlists
+    where list_type = p_list_type
+  loop
+    v_seen := array[]::text[];
+
+    foreach v_tier in array ARRAY['S', 'A', 'B', 'C', 'D', 'F']
+    loop
+      v_points := case v_tier
+        when 'S' then 6
+        when 'A' then 5
+        when 'B' then 4
+        when 'C' then 3
+        when 'D' then 2
+        else 1
+      end;
+
+      for v_key in
+        select jsonb_array_elements_text(coalesce(v_row.tiers -> v_tier, '[]'::jsonb))
+      loop
+        if v_key is null or btrim(v_key) = '' then
+          continue;
+        end if;
+
+        if v_key = any(v_seen) then
+          continue;
+        end if;
+
+        v_seen := array_append(v_seen, v_key);
+
+        v_totals := jsonb_set(
+          v_totals,
+          ARRAY[v_key],
+          to_jsonb(coalesce((v_totals ->> v_key)::numeric, 0) + v_points),
+          true
+        );
+
+        v_counts := jsonb_set(
+          v_counts,
+          ARRAY[v_key],
+          to_jsonb(coalesce((v_counts ->> v_key)::integer, 0) + 1),
+          true
+        );
+      end loop;
+    end loop;
+  end loop;
+
+  for v_key in
+    select jsonb_object_keys(v_totals)
+  loop
+    v_total := coalesce((v_totals ->> v_key)::numeric, 0);
+    v_count := coalesce((v_counts ->> v_key)::integer, 0);
+
+    if v_count <= 0 then
+      continue;
+    end if;
+
+    v_stats := jsonb_set(
+      v_stats,
+      ARRAY[v_key],
+      jsonb_build_object(
+        'average', round((v_total / v_count)::numeric, 4),
+        'count', v_count,
+        'total', v_total
+      ),
+      true
+    );
+  end loop;
+
+  return jsonb_build_object(
+    'stats_by_key', v_stats,
+    'player_count', v_player_count,
+    'submitted_count', v_submitted_count
+  );
+end;
+$$;
+
+revoke all on function public.get_platform_average_tierlist(text) from public;
+grant execute on function public.get_platform_average_tierlist(text) to authenticated;

--- a/supabase/migrations/20260428173000_platform_global_scope_rpcs.sql
+++ b/supabase/migrations/20260428173000_platform_global_scope_rpcs.sql
@@ -1,0 +1,275 @@
+-- Platform-wide analytics RPCs for global scope views.
+
+create or replace function public.get_platform_game_ids_by_player_count(
+  p_player_count_filter text default 'all'
+)
+returns table(game_id uuid)
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_target_count integer := null;
+begin
+  if p_player_count_filter is null or p_player_count_filter = 'all' then
+    v_target_count := null;
+  elsif p_player_count_filter ~ '^[0-9]+$' then
+    v_target_count := p_player_count_filter::integer;
+  else
+    raise exception 'Invalid player_count_filter: %', p_player_count_filter using errcode = '22023';
+  end if;
+
+  return query
+  select g.id
+  from games g
+  where v_target_count is null
+    or (
+      select count(*)
+      from game_players gp
+      where gp.game_id = g.id
+    ) = v_target_count;
+end;
+$$;
+
+create or replace function public.get_platform_leaderboard_payload(
+  p_player_count_filter text default 'all'
+)
+returns jsonb
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  with filtered_games as (
+    select g.id, g.date, g.created_at
+    from games g
+    join get_platform_game_ids_by_player_count(p_player_count_filter) fg
+      on fg.game_id = g.id
+  )
+  select jsonb_build_object(
+    'game_players', coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'game_id', gp.game_id,
+            'characters_played', gp.characters_played,
+            'total_toad_times', gp.total_toad_times,
+            'is_winner', gp.is_winner,
+            'winning_character', gp.winning_character,
+            'player', jsonb_build_object('id', p.id, 'name', p.name),
+            'game', jsonb_build_object('id', fg.id, 'date', fg.date, 'created_at', fg.created_at)
+          )
+        )
+        from game_players gp
+        join players p on p.id = gp.player_id
+        join filtered_games fg on fg.id = gp.game_id
+      ),
+      '[]'::jsonb
+    ),
+    'deaths', coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'game_id', d.game_id,
+            'player_id', d.player_id,
+            'killed_by_player_id', d.killed_by_player_id,
+            'death_type', jsonb_build_object('name', dt.name)
+          )
+        )
+        from game_player_deaths d
+        left join death_types dt on dt.id = d.death_type_id
+        join filtered_games fg on fg.id = d.game_id
+      ),
+      '[]'::jsonb
+    )
+  );
+$$;
+
+create or replace function public.get_platform_highscore_payload(
+  p_player_count_filter text default 'all'
+)
+returns jsonb
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  with filtered_games as (
+    select g.id, g.date
+    from games g
+    join get_platform_game_ids_by_player_count(p_player_count_filter) fg
+      on fg.game_id = g.id
+  )
+  select jsonb_build_object(
+    'highscores', coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'category', hs.category,
+            'value', hs.value,
+            'player', case
+              when p.id is null then null
+              else jsonb_build_object('id', p.id, 'name', p.name)
+            end,
+            'game', jsonb_build_object('id', fg.id, 'date', fg.date)
+          )
+        )
+        from game_highscores hs
+        left join players p on p.id = hs.player_id
+        join filtered_games fg on fg.id = hs.game_id
+      ),
+      '[]'::jsonb
+    ),
+    'game_players', coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'game_id', gp.game_id,
+            'total_toad_times', gp.total_toad_times,
+            'player', jsonb_build_object('id', p.id, 'name', p.name),
+            'game', jsonb_build_object('id', fg.id, 'date', fg.date)
+          )
+        )
+        from game_players gp
+        join players p on p.id = gp.player_id
+        join filtered_games fg on fg.id = gp.game_id
+      ),
+      '[]'::jsonb
+    ),
+    'deaths', coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'game_id', d.game_id,
+            'player_id', d.player_id
+          )
+        )
+        from game_player_deaths d
+        join filtered_games fg on fg.id = d.game_id
+      ),
+      '[]'::jsonb
+    )
+  );
+$$;
+
+create or replace function public.get_platform_stats_games()
+returns jsonb
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', g.id,
+        'optional_expansions', coalesce(to_jsonb(g.optional_expansions), '[]'::jsonb),
+        'ending', (
+          select jsonb_build_object('id', e.id, 'name', e.name, 'expansion', e.expansion)
+          from endings e
+          where e.id = g.ending_id
+        ),
+        'players', coalesce(
+          (
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', gp.id,
+                'characters_played', gp.characters_played,
+                'is_winner', gp.is_winner,
+                'winning_character', gp.winning_character,
+                'player', jsonb_build_object('id', p.id, 'name', p.name)
+              )
+            )
+            from game_players gp
+            join players p on p.id = gp.player_id
+            where gp.game_id = g.id
+          ),
+          '[]'::jsonb
+        ),
+        'expansion_events', coalesce(
+          (
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', gee.id,
+                'expansion', gee.expansion,
+                'event_type', gee.event_type,
+                'detail', gee.detail,
+                'character', gee.character,
+                'player', case
+                  when p.id is null then null
+                  else jsonb_build_object('id', p.id, 'name', p.name)
+                end
+              )
+            )
+            from game_expansion_events gee
+            left join players p on p.id = gee.player_id
+            where gee.game_id = g.id
+          ),
+          '[]'::jsonb
+        ),
+        'deaths', coalesce(
+          (
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', d.id,
+                'player_id', d.player_id,
+                'killed_by_player_id', d.killed_by_player_id,
+                'death_type', case
+                  when dt.id is null then null
+                  else jsonb_build_object('id', dt.id, 'name', dt.name)
+                end,
+                'character', case
+                  when c.id is null then null
+                  else jsonb_build_object('id', c.id, 'name', c.name)
+                end,
+                'killed_by', case
+                  when kb.id is null then null
+                  else jsonb_build_object('id', kb.id, 'name', kb.name)
+                end
+              )
+            )
+            from game_player_deaths d
+            left join death_types dt on dt.id = d.death_type_id
+            left join characters c on c.id = d.character_id
+            left join players kb on kb.id = d.killed_by_player_id
+            where d.game_id = g.id
+          ),
+          '[]'::jsonb
+        )
+      )
+    ),
+    '[]'::jsonb
+  )
+  from games g;
+$$;
+
+create or replace function public.get_platform_encounter_totals()
+returns table(encounter_name text, creature_wins bigint, player_wins bigint)
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select
+    es.encounter_name,
+    sum(es.creature_wins)::bigint as creature_wins,
+    sum(es.player_wins)::bigint as player_wins
+  from encounter_scores es
+  group by es.encounter_name
+  order by es.encounter_name;
+$$;
+
+revoke all on function public.get_platform_game_ids_by_player_count(text) from public;
+
+revoke all on function public.get_platform_leaderboard_payload(text) from public;
+grant execute on function public.get_platform_leaderboard_payload(text) to authenticated;
+
+revoke all on function public.get_platform_highscore_payload(text) from public;
+grant execute on function public.get_platform_highscore_payload(text) to authenticated;
+
+revoke all on function public.get_platform_stats_games() from public;
+grant execute on function public.get_platform_stats_games() to authenticated;
+
+revoke all on function public.get_platform_encounter_totals() from public;
+grant execute on function public.get_platform_encounter_totals() to authenticated;


### PR DESCRIPTION
## Summary
- add a new Average Tierlist page with character/pet tabs and visuals aligned with personal tierlists
- implement unranked-excluded averaging (unranked does not affect numerator or denominator)
- add Group / Global scope toggle for average tierlist
- make Global platform-wide via Supabase RPCs (not limited by viewer group membership) for:
  - Average Tierlist
  - Leaderboard
  - Highscores
  - Stats
  - Counters
- add migrations for new RPC functions and wire frontend hooks to use them for global scope
- update Character stats sorting so ties on selected column break by wins (then games)

## Database
- 20260428170000_platform_average_tierlist.sql
- 20260428173000_platform_global_scope_rpcs.sql

## Verification
- npm run lint
- npm run build
- npx supabase db push

Closes #62