### PR TITLE
[codex] improve mobile tierlist editing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ import Rulebooks from './pages/Rulebooks'
 import GroupHouseRules from './pages/GroupHouseRules'
 import Tierlist from './pages/Tierlist'
 import AverageTierlist from './pages/AverageTierlist'
+import Legal from './pages/Legal'
 
 const queryClient = new QueryClient()
 
@@ -48,6 +49,7 @@ export default function App() {
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
+            <Route path="/legal" element={<Legal />} />
             <Route element={<ProtectedLayout />}>
               <Route path="/setup" element={<Setup />} />
               <Route path="/setup-username" element={<SetupUsername />} />

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,7 +3,7 @@ import { Link, NavLink } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import GroupSwitcher from './GroupSwitcher'
 import PendingInvitesBanner from './PendingInvitesBanner'
-import { BUY_ME_A_COFFEE_COPY, BUY_ME_A_COFFEE_URL } from '../lib/supportLinks'
+import LegalFooter from './LegalFooter'
 
 const NAV_LINKS = [
   { to: '/', label: 'Home' },
@@ -146,33 +146,7 @@ export default function Layout({ children }) {
         <PendingInvitesBanner />
         {children}
       </main>
-
-      {/* Footer */}
-      <footer className="border-t border-gold-dim/15 bg-deep/50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col sm:flex-row items-center justify-between gap-3">
-            <p className="text-muted text-sm font-body">
-              Talisman Tracker — 4th Edition, All Expansions
-            </p>
-            <div className="flex items-center gap-4">
-              <p className="text-muted/50 text-xs font-body">
-                For the fellowship, by the fellowship
-              </p>
-              {BUY_ME_A_COFFEE_URL && (
-                <a
-                  href={BUY_ME_A_COFFEE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-2 rounded-full border border-gold-dim/20 px-3 py-1.5 text-xs font-heading tracking-wide text-gold/80 transition-colors hover:border-gold-dim/45 hover:text-gold"
-                >
-                  <span aria-hidden>☕</span>
-                  {BUY_ME_A_COFFEE_COPY.footerLabel}
-                </a>
-              )}
-            </div>
-          </div>
-        </div>
-      </footer>
+      <LegalFooter showSupport />
     </div>
   )
 }

--- a/src/components/LegalFooter.jsx
+++ b/src/components/LegalFooter.jsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom'
+import { BUY_ME_A_COFFEE_COPY, BUY_ME_A_COFFEE_URL } from '../lib/supportLinks'
+
+export const LEGAL_DISCLAIMER =
+  'Unofficial fan-made tracker. Not affiliated with, endorsed by, or sponsored by Games Workshop, Avalon Hill, Hasbro, Fantasy Flight Games, or Pegasus Spiele.'
+
+export default function LegalFooter({ compact = false, showSupport = false }) {
+  return (
+    <footer className="border-t border-gold-dim/15 bg-deep/50">
+      <div className={`max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 ${compact ? 'py-4' : 'py-6'}`}>
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <p className="text-muted text-sm font-body">
+              Talisman Tracker - 4th Edition, All Expansions
+            </p>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+              <Link
+                to="/legal"
+                className="text-xs font-heading tracking-wide text-gold/80 transition-colors hover:text-gold"
+              >
+                Legal
+              </Link>
+              <p className="text-muted/50 text-xs font-body">
+                For the fellowship, by the fellowship
+              </p>
+              {showSupport && BUY_ME_A_COFFEE_URL && (
+                <a
+                  href={BUY_ME_A_COFFEE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 rounded-full border border-gold-dim/20 px-3 py-1.5 text-xs font-heading tracking-wide text-gold/80 transition-colors hover:border-gold-dim/45 hover:text-gold"
+                >
+                  {BUY_ME_A_COFFEE_COPY.footerLabel}
+                </a>
+              )}
+            </div>
+          </div>
+          <p className="max-w-4xl text-xs leading-relaxed text-muted/70 font-body">
+            {LEGAL_DISCLAIMER}
+          </p>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/tierlist/DesktopTierBoard.jsx
+++ b/src/components/tierlist/DesktopTierBoard.jsx
@@ -1,0 +1,343 @@
+import { useEffect, useState } from 'react'
+import {
+  DetailPanel,
+  EntityImage,
+} from './tierlistShared'
+import {
+  TIERS,
+  TIER_STYLES,
+  tileSrcFor,
+} from './tierlistConfig'
+
+function TierTile({
+  item,
+  listType,
+  onDragStart,
+  onDragEnd,
+  onHover,
+  onTileDrop,
+  isDragging,
+  isPreviewed,
+  dropSide,
+  isReadOnly = false,
+}) {
+  const isPet = listType === 'pet'
+  const tileFrameClass = isPet ? 'w-12 h-16 rounded-md' : 'w-14 h-14 rounded-lg'
+  const tileImageClass = isPet
+    ? 'w-full h-full object-contain pointer-events-none p-0.5 bg-surface'
+    : 'w-full h-full object-cover pointer-events-none'
+
+  const handleDragOver = e => {
+    if (!onTileDrop || isReadOnly) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.dataTransfer.dropEffect = 'move'
+    const rect = e.currentTarget.getBoundingClientRect()
+    const side = e.clientX < rect.left + rect.width / 2 ? 'before' : 'after'
+    onTileDrop.hover(item.key, side)
+  }
+
+  const handleDrop = e => {
+    if (!onTileDrop || isReadOnly) return
+    e.preventDefault()
+    e.stopPropagation()
+    const rect = e.currentTarget.getBoundingClientRect()
+    const side = e.clientX < rect.left + rect.width / 2 ? 'before' : 'after'
+    onTileDrop.drop(item.key, side)
+  }
+
+  return (
+    <div className="relative">
+      {dropSide === 'before' && <div className="absolute -left-1 top-0 bottom-0 w-0.5 bg-gold rounded-full pointer-events-none" />}
+      {dropSide === 'after' && <div className="absolute -right-1 top-0 bottom-0 w-0.5 bg-gold rounded-full pointer-events-none" />}
+      <div
+        draggable={!isReadOnly}
+        onDragStart={e => {
+          if (isReadOnly) return
+          e.dataTransfer.effectAllowed = 'move'
+          e.dataTransfer.setData('text/plain', item.key)
+          onDragStart(item.key)
+        }}
+        onDragEnd={onDragEnd}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onMouseEnter={() => onHover(item.key)}
+        onFocus={() => onHover(item.key)}
+        tabIndex={isReadOnly ? -1 : 0}
+        className={`${tileFrameClass} overflow-hidden border bg-deep cursor-grab active:cursor-grabbing transition-colors ${
+          isPreviewed ? 'border-gold ring-1 ring-gold/40' : 'border-gold-dim/30 hover:border-gold/60'
+        } ${isDragging ? 'opacity-40' : ''} ${isReadOnly ? 'cursor-default active:cursor-default' : ''}`}
+        title={item.name}
+      >
+        <EntityImage
+          key={item.key}
+          src={tileSrcFor(item, listType)}
+          name={item.name}
+          className={tileImageClass}
+        />
+      </div>
+    </div>
+  )
+}
+
+function TierRow({
+  tier,
+  keys,
+  itemsByKey,
+  listType,
+  onDrop,
+  onDragOver,
+  onDragStart,
+  onDragEnd,
+  onHover,
+  onTileHover,
+  dropTarget,
+  draggingKey,
+  previewKey,
+  isOver,
+  emptyTier,
+  isReadOnly = false,
+}) {
+  const style = TIER_STYLES[tier]
+  const tileDropApi = {
+    hover: (beforeKey, side) => onTileHover(tier, beforeKey, side),
+    drop: (beforeKey, side) => onDrop(tier, { beforeKey, side }),
+  }
+
+  return (
+    <div
+      onDragOver={e => {
+        if (isReadOnly) return
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        onDragOver(tier)
+      }}
+      onDrop={e => {
+        if (isReadOnly) return
+        e.preventDefault()
+        onDrop(tier)
+      }}
+      className={`flex items-stretch border rounded-lg overflow-hidden transition-colors ${style.row} ${isOver ? 'ring-2 ring-gold/60' : ''}`}
+    >
+      <div className={`flex items-center justify-center w-16 font-display text-3xl tracking-wider border-r ${style.label}`}>
+        {tier}
+      </div>
+      <div className="flex-1 min-h-[72px] p-2 flex flex-wrap gap-2 items-start">
+        {keys.length === 0 ? (
+          <span className="text-muted/60 text-xs font-body italic self-center px-2">{emptyTier}</span>
+        ) : (
+          keys.map(key => {
+            const item = itemsByKey.get(key)
+            if (!item) return null
+            const isDropTargetTile = dropTarget && dropTarget.tier === tier && dropTarget.beforeKey === key
+            return (
+              <TierTile
+                key={key}
+                item={item}
+                listType={listType}
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+                onHover={onHover}
+                onTileDrop={tileDropApi}
+                isDragging={draggingKey === key}
+                isPreviewed={previewKey === key}
+                dropSide={isDropTargetTile ? dropTarget.side : null}
+                isReadOnly={isReadOnly}
+              />
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Pool({
+  listType,
+  poolTitle,
+  emptyPool,
+  keys,
+  itemsByKey,
+  onDrop,
+  onDragOver,
+  onDragStart,
+  onDragEnd,
+  onHover,
+  draggingKey,
+  previewKey,
+  isOver,
+  isReadOnly = false,
+}) {
+  return (
+    <div
+      onDragOver={e => {
+        if (isReadOnly) return
+        e.preventDefault()
+        e.dataTransfer.dropEffect = 'move'
+        onDragOver('pool')
+      }}
+      onDrop={e => {
+        if (isReadOnly) return
+        e.preventDefault()
+        onDrop('pool')
+      }}
+      className={`bg-surface border border-gold-dim/20 rounded-xl p-4 transition-colors ${isOver ? 'ring-2 ring-gold/60' : ''}`}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-heading text-lg text-parchment tracking-wide">{poolTitle}</h2>
+        <span className="text-xs font-body text-muted">{keys.length} unranked</span>
+      </div>
+      <div className="flex flex-wrap gap-2 min-h-[72px]">
+        {keys.length === 0 ? (
+          <p className="text-muted text-sm font-body italic">{emptyPool}</p>
+        ) : (
+          keys.map(key => {
+            const item = itemsByKey.get(key)
+            if (!item) return null
+            return (
+              <TierTile
+                key={key}
+                item={item}
+                listType={listType}
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+                onHover={onHover}
+                isDragging={draggingKey === key}
+                isPreviewed={previewKey === key}
+                isReadOnly={isReadOnly}
+              />
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function DesktopTierBoard({
+  tiers,
+  poolKeys,
+  itemsByKey,
+  listType,
+  config,
+  previewItem,
+  previewKey,
+  onPreview,
+  onMove,
+  isReadOnly,
+}) {
+  const [draggingKey, setDraggingKey] = useState(null)
+  const [overZone, setOverZone] = useState(null)
+  const [dropTarget, setDropTarget] = useState(null)
+
+  useEffect(() => {
+    if (!draggingKey) return
+    const NAV_OFFSET = 64
+    const EDGE = 100
+    const MAX_SPEED = 18
+    let cursorY = -1
+    let frame = 0
+
+    const onDragOver = e => {
+      cursorY = e.clientY
+    }
+
+    const tick = () => {
+      const h = window.innerHeight
+      let speed = 0
+      if (cursorY >= 0) {
+        const topZoneEnd = NAV_OFFSET + EDGE
+        if (cursorY < topZoneEnd) {
+          const intensity = Math.max(0, (topZoneEnd - cursorY) / EDGE)
+          speed = -Math.ceil(intensity * MAX_SPEED)
+        } else if (cursorY > h - EDGE) {
+          const intensity = Math.min(1, (cursorY - (h - EDGE)) / EDGE)
+          speed = Math.ceil(intensity * MAX_SPEED)
+        }
+      }
+      if (speed !== 0) window.scrollBy(0, speed)
+      frame = requestAnimationFrame(tick)
+    }
+
+    window.addEventListener('dragover', onDragOver)
+    frame = requestAnimationFrame(tick)
+
+    return () => {
+      window.removeEventListener('dragover', onDragOver)
+      cancelAnimationFrame(frame)
+    }
+  }, [draggingKey])
+
+  const handleDragStart = key => setDraggingKey(key)
+  const handleDragEnd = () => {
+    setDraggingKey(null)
+    setOverZone(null)
+    setDropTarget(null)
+  }
+  const handleDragOver = zone => {
+    setOverZone(zone)
+    setDropTarget(null)
+  }
+  const handleTileHover = (tier, beforeKey, side) => {
+    setOverZone(tier)
+    setDropTarget({ tier, beforeKey, side })
+  }
+  const handleHover = key => onPreview(key)
+
+  const handleDrop = (targetZone, opts) => {
+    if (!draggingKey) return
+    onMove(draggingKey, targetZone, opts)
+    setDraggingKey(null)
+    setOverZone(null)
+    setDropTarget(null)
+  }
+
+  return (
+    <div className="space-y-3">
+      {TIERS.map(t => (
+        <TierRow
+          key={t}
+          tier={t}
+          keys={tiers[t] ?? []}
+          itemsByKey={itemsByKey}
+          listType={listType}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onHover={handleHover}
+          onTileHover={handleTileHover}
+          dropTarget={dropTarget}
+          draggingKey={draggingKey}
+          previewKey={previewKey}
+          isOver={overZone === t}
+          emptyTier={config.emptyTier}
+          isReadOnly={isReadOnly}
+        />
+      ))}
+
+      <div className="pt-4">
+        <Pool
+          listType={listType}
+          poolTitle={config.poolTitle}
+          emptyPool={config.emptyPool}
+          keys={poolKeys}
+          itemsByKey={itemsByKey}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onHover={handleHover}
+          draggingKey={draggingKey}
+          previewKey={previewKey}
+          isOver={overZone === 'pool'}
+          isReadOnly={isReadOnly}
+        />
+      </div>
+
+      <div className="pt-4">
+        <DetailPanel item={previewItem} listType={listType} hoverText={config.hoverText} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/tierlist/MobileTierBoard.jsx
+++ b/src/components/tierlist/MobileTierBoard.jsx
@@ -1,0 +1,305 @@
+import { useMemo, useState } from 'react'
+import {
+  DetailPanel,
+  EntityImage,
+} from './tierlistShared'
+import {
+  TIERS,
+  TIER_STYLES,
+  tileSrcFor,
+} from './tierlistConfig'
+
+function MobileTile({
+  item,
+  listType,
+  isSelected,
+  isPreviewed,
+  canPlaceAround,
+  onSelect,
+  onPlaceBefore,
+  onPlaceAfter,
+}) {
+  const isPet = listType === 'pet'
+  const tileFrameClass = isPet ? 'w-12 h-16 rounded-md' : 'w-14 h-14 rounded-lg'
+  const tileImageClass = isPet
+    ? 'w-full h-full object-contain pointer-events-none p-0.5 bg-surface'
+    : 'w-full h-full object-cover pointer-events-none'
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {canPlaceAround && (
+        <button
+          type="button"
+          onClick={onPlaceBefore}
+          className="px-2 py-1 rounded border border-gold-dim/30 bg-deep text-[10px] font-body text-gold-dim"
+        >
+          Before
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onSelect}
+        className={`${tileFrameClass} overflow-hidden border bg-deep transition-colors ${
+          isSelected
+            ? 'border-gold ring-2 ring-gold/50'
+            : isPreviewed
+              ? 'border-gold ring-1 ring-gold/40'
+              : 'border-gold-dim/30'
+        }`}
+        title={item.name}
+      >
+        <EntityImage
+          key={item.key}
+          src={tileSrcFor(item, listType)}
+          name={item.name}
+          className={tileImageClass}
+        />
+      </button>
+      {canPlaceAround && (
+        <button
+          type="button"
+          onClick={onPlaceAfter}
+          className="px-2 py-1 rounded border border-gold-dim/30 bg-deep text-[10px] font-body text-gold-dim"
+        >
+          After
+        </button>
+      )}
+    </div>
+  )
+}
+
+function MobileTierRow({
+  tier,
+  keys,
+  itemsByKey,
+  listType,
+  selectedKey,
+  previewKey,
+  emptyTier,
+  isReadOnly,
+  onSelect,
+  onAppend,
+  onPlace,
+}) {
+  const style = TIER_STYLES[tier]
+  const canAppend = selectedKey && !isReadOnly
+
+  return (
+    <div className={`flex items-stretch border rounded-lg overflow-hidden transition-colors ${style.row} ${canAppend ? 'ring-1 ring-gold/30' : ''}`}>
+      <button
+        type="button"
+        onClick={() => {
+          if (canAppend) onAppend(tier)
+        }}
+        className={`flex items-center justify-center w-14 shrink-0 font-display text-2xl tracking-wider border-r ${style.label}`}
+      >
+        {tier}
+      </button>
+      <div className="flex-1 min-h-[86px] p-2">
+        {keys.length === 0 ? (
+          <button
+            type="button"
+            onClick={() => {
+              if (canAppend) onAppend(tier)
+            }}
+            disabled={!canAppend}
+            className="w-full min-h-[68px] rounded-md border border-dashed border-gold-dim/20 text-muted/60 text-xs font-body italic disabled:cursor-default"
+          >
+            {canAppend ? `Place in ${tier}` : emptyTier}
+          </button>
+        ) : (
+          <div className="flex flex-wrap gap-3 items-start">
+            {keys.map(key => {
+              const item = itemsByKey.get(key)
+              if (!item) return null
+              const canPlaceAround = selectedKey && selectedKey !== key && !isReadOnly
+              return (
+                <MobileTile
+                  key={key}
+                  item={item}
+                  listType={listType}
+                  isSelected={selectedKey === key}
+                  isPreviewed={previewKey === key}
+                  canPlaceAround={canPlaceAround}
+                  onSelect={() => onSelect(key)}
+                  onPlaceBefore={() => onPlace(tier, key, 'before')}
+                  onPlaceAfter={() => onPlace(tier, key, 'after')}
+                />
+              )
+            })}
+            {canAppend && (
+              <button
+                type="button"
+                onClick={() => onAppend(tier)}
+                className="self-stretch min-h-14 px-3 rounded-md border border-dashed border-gold-dim/40 text-xs font-body text-gold-dim"
+              >
+                End
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function MobilePool({
+  listType,
+  poolTitle,
+  emptyPool,
+  keys,
+  itemsByKey,
+  selectedKey,
+  previewKey,
+  isReadOnly,
+  onSelect,
+  onMoveToPool,
+}) {
+  const canMoveToPool = selectedKey && !isReadOnly
+
+  return (
+    <div className={`bg-surface border border-gold-dim/20 rounded-xl p-4 transition-colors ${canMoveToPool ? 'ring-1 ring-gold/30' : ''}`}>
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <h2 className="font-heading text-lg text-parchment tracking-wide">{poolTitle}</h2>
+        <span className="text-xs font-body text-muted">{keys.length} unranked</span>
+      </div>
+      {canMoveToPool && (
+        <button
+          type="button"
+          onClick={onMoveToPool}
+          className="mb-3 w-full rounded-md border border-dashed border-gold-dim/40 px-3 py-2 text-xs font-body text-gold-dim"
+        >
+          Move selected to pool
+        </button>
+      )}
+      <div className="flex flex-wrap gap-3 min-h-[72px]">
+        {keys.length === 0 ? (
+          <p className="text-muted text-sm font-body italic">{emptyPool}</p>
+        ) : (
+          keys.map(key => {
+            const item = itemsByKey.get(key)
+            if (!item) return null
+            return (
+              <MobileTile
+                key={key}
+                item={item}
+                listType={listType}
+                isSelected={selectedKey === key}
+                isPreviewed={previewKey === key}
+                canPlaceAround={false}
+                onSelect={() => onSelect(key)}
+              />
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function MobileTierBoard({
+  tiers,
+  poolKeys,
+  itemsByKey,
+  listType,
+  config,
+  previewItem,
+  previewKey,
+  onPreview,
+  onMove,
+  isReadOnly,
+}) {
+  const [selectedKey, setSelectedKey] = useState(null)
+  const activeSelectedKey = selectedKey && itemsByKey.has(selectedKey) ? selectedKey : null
+
+  const selectedItem = useMemo(
+    () => itemsByKey.get(activeSelectedKey) ?? null,
+    [itemsByKey, activeSelectedKey],
+  )
+
+  const handleSelect = key => {
+    onPreview(key)
+    if (isReadOnly) return
+    setSelectedKey(prev => (prev === key ? null : key))
+  }
+
+  const handleAppend = tier => {
+    if (!activeSelectedKey || isReadOnly) return
+    onMove(activeSelectedKey, tier)
+    setSelectedKey(null)
+  }
+
+  const handlePlace = (tier, beforeKey, side) => {
+    if (!activeSelectedKey || isReadOnly) return
+    onMove(activeSelectedKey, tier, { beforeKey, side })
+    setSelectedKey(null)
+  }
+
+  const handleMoveToPool = () => {
+    if (!activeSelectedKey || isReadOnly) return
+    onMove(activeSelectedKey, 'pool')
+    setSelectedKey(null)
+  }
+
+  return (
+    <div className="space-y-3">
+      {!isReadOnly && (
+        <div className="sticky top-16 z-20 rounded-lg border border-gold-dim/30 bg-deep/95 p-3 shadow-lg shadow-black/40">
+          {selectedItem ? (
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0">
+                <p className="text-xs font-body uppercase tracking-widest text-gold-dim">Selected</p>
+                <p className="truncate font-heading text-base text-parchment">{selectedItem.name}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedKey(null)}
+                className="shrink-0 rounded border border-gold-dim/30 px-3 py-1.5 text-xs font-body text-muted"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <p className="text-xs font-body text-muted">Tap an item to select it, then tap a tier or a Before/After position.</p>
+          )}
+        </div>
+      )}
+
+      {TIERS.map(t => (
+        <MobileTierRow
+          key={t}
+          tier={t}
+          keys={tiers[t] ?? []}
+          itemsByKey={itemsByKey}
+          listType={listType}
+          selectedKey={activeSelectedKey}
+          previewKey={previewKey}
+          emptyTier={config.emptyTier}
+          isReadOnly={isReadOnly}
+          onSelect={handleSelect}
+          onAppend={handleAppend}
+          onPlace={handlePlace}
+        />
+      ))}
+
+      <div className="pt-4">
+        <MobilePool
+          listType={listType}
+          poolTitle={config.poolTitle}
+          emptyPool={config.emptyPool}
+          keys={poolKeys}
+          itemsByKey={itemsByKey}
+          selectedKey={activeSelectedKey}
+          previewKey={previewKey}
+          isReadOnly={isReadOnly}
+          onSelect={handleSelect}
+          onMoveToPool={handleMoveToPool}
+        />
+      </div>
+
+      <div className="pt-4">
+        <DetailPanel item={previewItem} listType={listType} hoverText={config.hoverText} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/tierlist/tierlistConfig.js
+++ b/src/components/tierlist/tierlistConfig.js
@@ -1,0 +1,90 @@
+import { AVAILABLE_ICONS } from '../../data/availableIcons'
+
+const iconExtMap = new Map(AVAILABLE_ICONS.map(i => [i.key, i.ext]))
+
+export const TIERS = ['S', 'A', 'B', 'C', 'D', 'F']
+
+export const TIER_STYLES = {
+  S: { label: 'bg-red-900/60 text-red-100 border-red-700/60', row: 'border-red-900/40 bg-red-950/20' },
+  A: { label: 'bg-orange-900/60 text-orange-100 border-orange-700/60', row: 'border-orange-900/40 bg-orange-950/20' },
+  B: { label: 'bg-yellow-900/60 text-yellow-100 border-yellow-700/60', row: 'border-yellow-900/40 bg-yellow-950/20' },
+  C: { label: 'bg-emerald-900/60 text-emerald-100 border-emerald-700/60', row: 'border-emerald-900/40 bg-emerald-950/20' },
+  D: { label: 'bg-blue-900/60 text-blue-100 border-blue-700/60', row: 'border-blue-900/40 bg-blue-950/20' },
+  F: { label: 'bg-purple-900/60 text-purple-100 border-purple-700/60', row: 'border-purple-900/40 bg-purple-950/20' },
+}
+
+export const EXPANSION_LABELS = {
+  base: 'Base Game',
+  reaper: 'The Reaper',
+  dungeon: 'The Dungeon',
+  highland: 'The Highland',
+  sacred_pool: 'The Sacred Pool',
+  harbinger: 'The Harbinger',
+  frostmarch: 'The Frostmarch',
+  blood_moon: 'The Blood Moon',
+  city: 'The City',
+  woodland: 'The Woodland',
+  dragon: 'The Dragon',
+  firelands: 'The Firelands',
+  cataclysm: 'The Cataclysm',
+}
+
+export const LIST_CONFIG = {
+  character: {
+    poolTitle: 'Character Pool',
+    emptyPool: 'All characters ranked.',
+    emptyTier: 'Drop characters here',
+    hoverText: 'Hover a character to see details.',
+    editHint: 'Drag characters between tiers. Hover a portrait for details.',
+    mobileEditHint: 'Tap a character, then choose a tier or position.',
+  },
+  pet: {
+    poolTitle: 'Pet Pool',
+    emptyPool: 'All pets ranked.',
+    emptyTier: 'Drop pets here',
+    hoverText: 'Hover a pet to see details.',
+    editHint: 'Drag pets between tiers. Hover a portrait for details.',
+    mobileEditHint: 'Tap a pet, then choose a tier or position.',
+  },
+}
+
+export function tabToListType(tab) {
+  return tab === 'pets' ? 'pet' : 'character'
+}
+
+export function listTypeToTab(listType) {
+  return listType === 'pet' ? 'pets' : 'characters'
+}
+
+export function tileSrcFor(item, listType) {
+  if (listType === 'pet') {
+    return `/pets/${item.key}.png`
+  }
+  return `/icons/${item.key}${iconExtMap.get(item.key) ?? '.png'}`
+}
+
+export function detailSrcFor(item, listType) {
+  if (listType === 'pet') {
+    return `/pets/${item.key}.png`
+  }
+  return `/characters/${item.key}.webp`
+}
+
+export function moveKeyInTiers(prev, key, targetZone, opts) {
+  const next = {}
+  for (const tier of TIERS) next[tier] = (prev[tier] ?? []).filter(k => k !== key)
+
+  if (targetZone !== 'pool') {
+    const tierArr = next[targetZone] ?? []
+    if (opts && opts.beforeKey && opts.beforeKey !== key) {
+      let idx = tierArr.indexOf(opts.beforeKey)
+      if (idx === -1) idx = tierArr.length
+      if (opts.side === 'after') idx += 1
+      next[targetZone] = [...tierArr.slice(0, idx), key, ...tierArr.slice(idx)]
+    } else {
+      next[targetZone] = [...tierArr, key]
+    }
+  }
+
+  return next
+}

--- a/src/components/tierlist/tierlistShared.jsx
+++ b/src/components/tierlist/tierlistShared.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { EXPANSION_LABELS, detailSrcFor } from './tierlistConfig'
+
+export function EntityImage({ src, name, className, fallbackTextSize = 'text-xs' }) {
+  const [errored, setErrored] = useState(false)
+  if (errored) {
+    return (
+      <div className={`${className} flex items-center justify-center bg-deep`}>
+        <span className={`font-heading text-gold-dim ${fallbackTextSize} text-center px-1`}>
+          {name}
+        </span>
+      </div>
+    )
+  }
+  return (
+    <img
+      src={src}
+      alt={name}
+      className={className}
+      onError={() => setErrored(true)}
+    />
+  )
+}
+
+export function DetailPanel({ item, listType, hoverText }) {
+  const isPet = listType === 'pet'
+  const detailFrameClass = isPet
+    ? 'w-full max-w-sm aspect-[5/7] rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70'
+    : 'w-full max-w-lg aspect-[3/2] rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70'
+
+  if (!item) {
+    return (
+      <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 flex items-center justify-center min-h-28">
+        <p className="text-muted text-sm font-body italic">{hoverText}</p>
+      </div>
+    )
+  }
+
+  function PetDetailArtwork() {
+    const [failed, setFailed] = useState(false)
+    if (failed) {
+      return (
+        <div className="w-full h-full p-6 flex flex-col items-center justify-center gap-3 text-center">
+          <p className="font-heading text-lg text-gold-light">{item.name}</p>
+          <p className="text-sm font-body text-parchment/80">
+            {item.ability_text ?? 'Image coming soon.'}
+          </p>
+        </div>
+      )
+    }
+    return (
+      <img
+        src={detailSrcFor(item, listType)}
+        alt={item.name}
+        className="w-full h-full object-contain p-1 bg-surface"
+        onError={() => setFailed(true)}
+      />
+    )
+  }
+
+  return (
+    <div className="bg-surface border border-gold-dim/20 rounded-xl p-6 flex flex-col items-center gap-4">
+      <div className="text-center">
+        <p className="text-xs font-body text-gold-dim uppercase tracking-widest mb-1">
+          {EXPANSION_LABELS[item.expansion] ?? item.expansion ?? ''}
+        </p>
+        <h3 className="font-heading text-2xl text-parchment tracking-wide">{item.name}</h3>
+      </div>
+      <div className={detailFrameClass}>
+        {listType === 'pet' ? (
+          <PetDetailArtwork key={item.key} />
+        ) : (
+          <EntityImage
+            src={detailSrcFor(item, listType)}
+            name={item.name}
+            className="w-full h-full object-cover"
+            fallbackTextSize="text-base"
+          />
+        )}
+      </div>
+      {listType === 'pet' && item.ability_text && (
+        <p className="text-sm font-body text-parchment/80 text-center max-w-lg">
+          {item.ability_text}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Legal.jsx
+++ b/src/pages/Legal.jsx
@@ -1,0 +1,69 @@
+import { Link } from 'react-router-dom'
+import LegalFooter, { LEGAL_DISCLAIMER } from '../components/LegalFooter'
+
+export default function Legal() {
+  return (
+    <div className="min-h-screen flex flex-col bg-deep">
+      <header className="border-b border-gold-dim/15 bg-deep/90">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-5">
+          <Link to="/" className="inline-flex items-center gap-2.5 text-gold hover:text-gold-light transition-colors">
+            <img src="/icons/talisman-logo.png" alt="" className="w-8 h-8" />
+            <span className="font-display text-lg tracking-wider">Talisman Tracker</span>
+          </Link>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        <section className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+          <div className="max-w-3xl space-y-8">
+            <div className="space-y-3">
+              <p className="font-heading text-sm tracking-[0.18em] uppercase text-gold-dim">
+                Legal notice
+              </p>
+              <h1 className="font-display text-3xl sm:text-4xl text-gold tracking-wide">
+                Unofficial fan project
+              </h1>
+              <p className="text-parchment/80 leading-relaxed">
+                {LEGAL_DISCLAIMER}
+              </p>
+            </div>
+
+            <section className="space-y-3">
+              <h2 className="font-heading text-xl text-gold-light">Purpose</h2>
+              <p className="text-parchment/75 leading-relaxed">
+                This site is a non-commercial game logging and statistics tracker for players who already own and play the game. It is intended for recording private group sessions, player results, house rules, and table history.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-heading text-xl text-gold-light">Ownership</h2>
+              <p className="text-parchment/75 leading-relaxed">
+                Talisman, related names, logos, characters, settings, artwork, rulebooks, and other game materials belong to their respective rights holders. This site does not claim ownership of those materials and does not claim official status.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-heading text-xl text-gold-light">External Materials</h2>
+              <p className="text-parchment/75 leading-relaxed">
+                References to game names, character names, expansions, and rule materials are used to identify table activity and help players record their own games. Any external links are provided as references only; rights remain with the original owners and publishers.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-heading text-xl text-gold-light">Takedown Requests</h2>
+              <p className="text-parchment/75 leading-relaxed">
+                If you are a rights holder and believe content on this site should be removed or changed, contact{' '}
+                <a href="mailto:dadaanbom@gmail.com" className="text-gold hover:text-gold-light transition-colors">
+                  dadaanbom@gmail.com
+                </a>{' '}
+                with the affected URL and a short description of the issue. Requests will be reviewed and handled in good faith.
+              </p>
+            </section>
+          </div>
+        </section>
+      </main>
+
+      <LegalFooter compact />
+    </div>
+  )
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
 import { sanitizeNext } from '../utils/redirect'
+import LegalFooter from '../components/LegalFooter'
 
 function normalizeUsername(value) {
   return value.trim().toLowerCase()
@@ -43,8 +44,9 @@ export default function Login() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 bg-deep">
-      <div className="max-w-md w-full space-y-8">
+    <div className="min-h-screen flex flex-col bg-deep">
+      <div className="flex-1 flex items-center justify-center px-4 py-10">
+        <div className="max-w-md w-full space-y-8">
         <div className="text-center space-y-2">
           <img src="/icons/talisman-logo.png" alt="" className="w-16 h-16 mx-auto" />
           <h1 className="font-display text-3xl text-gold tracking-wider">Talisman Tracker</h1>
@@ -88,7 +90,9 @@ export default function Login() {
             Create one
           </Link>
         </p>
+        </div>
       </div>
+      <LegalFooter compact />
     </div>
   )
 }

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
 import { supabase } from '../supabaseClient'
+import LegalFooter from '../components/LegalFooter'
 
 function normalizeUsername(value) {
   return value.trim().toLowerCase()
@@ -92,8 +93,9 @@ export default function Register() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 bg-deep">
-      <div className="max-w-md w-full space-y-8">
+    <div className="min-h-screen flex flex-col bg-deep">
+      <div className="flex-1 flex items-center justify-center px-4 py-10">
+        <div className="max-w-md w-full space-y-8">
         <div className="text-center space-y-2">
           <img src="/icons/talisman-logo.png" alt="" className="w-16 h-16 mx-auto" />
           <h1 className="font-display text-3xl text-gold tracking-wider">Talisman Tracker</h1>
@@ -163,7 +165,9 @@ export default function Register() {
             Sign in
           </Link>
         </p>
+        </div>
       </div>
+      <LegalFooter compact />
     </div>
   )
 }

--- a/src/pages/Tierlist.jsx
+++ b/src/pages/Tierlist.jsx
@@ -1,372 +1,21 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import DesktopTierBoard from '../components/tierlist/DesktopTierBoard'
+import MobileTierBoard from '../components/tierlist/MobileTierBoard'
+import {
+  LIST_CONFIG,
+  TIERS,
+  listTypeToTab,
+  moveKeyInTiers,
+  tabToListType,
+} from '../components/tierlist/tierlistConfig'
+import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
 import { useIcons } from '../hooks/useIcons'
 import { usePets } from '../hooks/usePets'
-import { AVAILABLE_ICONS } from '../data/availableIcons'
 import { usePlayers } from '../hooks/usePlayers'
-import { useCurrentPlayer } from '../hooks/useCurrentPlayer'
-import { useTierlist, EMPTY_TIERS } from '../hooks/useTierlist'
 import { useSaveTierlist } from '../hooks/useSaveTierlist'
+import { EMPTY_TIERS, useTierlist } from '../hooks/useTierlist'
 import { canEditTierlist } from '../lib/accessControl'
-
-const iconExtMap = new Map(AVAILABLE_ICONS.map(i => [i.key, i.ext]))
-
-const TIERS = ['S', 'A', 'B', 'C', 'D', 'F']
-
-const TIER_STYLES = {
-  S: { label: 'bg-red-900/60 text-red-100 border-red-700/60', row: 'border-red-900/40 bg-red-950/20' },
-  A: { label: 'bg-orange-900/60 text-orange-100 border-orange-700/60', row: 'border-orange-900/40 bg-orange-950/20' },
-  B: { label: 'bg-yellow-900/60 text-yellow-100 border-yellow-700/60', row: 'border-yellow-900/40 bg-yellow-950/20' },
-  C: { label: 'bg-emerald-900/60 text-emerald-100 border-emerald-700/60', row: 'border-emerald-900/40 bg-emerald-950/20' },
-  D: { label: 'bg-blue-900/60 text-blue-100 border-blue-700/60', row: 'border-blue-900/40 bg-blue-950/20' },
-  F: { label: 'bg-purple-900/60 text-purple-100 border-purple-700/60', row: 'border-purple-900/40 bg-purple-950/20' },
-}
-
-const EXPANSION_LABELS = {
-  base: 'Base Game',
-  reaper: 'The Reaper',
-  dungeon: 'The Dungeon',
-  highland: 'The Highland',
-  sacred_pool: 'The Sacred Pool',
-  harbinger: 'The Harbinger',
-  frostmarch: 'The Frostmarch',
-  blood_moon: 'The Blood Moon',
-  city: 'The City',
-  woodland: 'The Woodland',
-  dragon: 'The Dragon',
-  firelands: 'The Firelands',
-  cataclysm: 'The Cataclysm',
-}
-
-const LIST_CONFIG = {
-  character: {
-    poolTitle: 'Character Pool',
-    emptyPool: 'All characters ranked.',
-    emptyTier: 'Drop characters here',
-    hoverText: 'Hover a character to see details.',
-    editHint: 'Drag characters between tiers. Hover a portrait for details.',
-  },
-  pet: {
-    poolTitle: 'Pet Pool',
-    emptyPool: 'All pets ranked.',
-    emptyTier: 'Drop pets here',
-    hoverText: 'Hover a pet to see details.',
-    editHint: 'Drag pets between tiers. Hover a portrait for details.',
-  },
-}
-
-function tabToListType(tab) {
-  return tab === 'pets' ? 'pet' : 'character'
-}
-
-function listTypeToTab(listType) {
-  return listType === 'pet' ? 'pets' : 'characters'
-}
-
-function tileSrcFor(item, listType) {
-  if (listType === 'pet') {
-    return `/pets/${item.key}.png`
-  }
-  return `/icons/${item.key}${iconExtMap.get(item.key) ?? '.png'}`
-}
-
-function detailSrcFor(item, listType) {
-  if (listType === 'pet') {
-    return `/pets/${item.key}.png`
-  }
-  return `/characters/${item.key}.webp`
-}
-
-function EntityImage({ src, name, className, fallbackTextSize = 'text-xs' }) {
-  const [errored, setErrored] = useState(false)
-  if (errored) {
-    return (
-      <div className={`${className} flex items-center justify-center bg-deep`}>
-        <span className={`font-heading text-gold-dim ${fallbackTextSize} text-center px-1`}>
-          {name}
-        </span>
-      </div>
-    )
-  }
-  return (
-    <img
-      src={src}
-      alt={name}
-      className={className}
-      onError={() => setErrored(true)}
-    />
-  )
-}
-
-function TierTile({
-  item,
-  listType,
-  onDragStart,
-  onDragEnd,
-  onHover,
-  onTileDrop,
-  isDragging,
-  isPreviewed,
-  dropSide,
-  isReadOnly = false,
-}) {
-  const isPet = listType === 'pet'
-  const tileFrameClass = isPet ? 'w-12 h-16 rounded-md' : 'w-14 h-14 rounded-lg'
-  const tileImageClass = isPet
-    ? 'w-full h-full object-contain pointer-events-none p-0.5 bg-surface'
-    : 'w-full h-full object-cover pointer-events-none'
-
-  const handleDragOver = e => {
-    if (!onTileDrop || isReadOnly) return
-    e.preventDefault()
-    e.stopPropagation()
-    e.dataTransfer.dropEffect = 'move'
-    const rect = e.currentTarget.getBoundingClientRect()
-    const side = e.clientX < rect.left + rect.width / 2 ? 'before' : 'after'
-    onTileDrop.hover(item.key, side)
-  }
-
-  const handleDrop = e => {
-    if (!onTileDrop || isReadOnly) return
-    e.preventDefault()
-    e.stopPropagation()
-    const rect = e.currentTarget.getBoundingClientRect()
-    const side = e.clientX < rect.left + rect.width / 2 ? 'before' : 'after'
-    onTileDrop.drop(item.key, side)
-  }
-
-  return (
-    <div className="relative">
-      {dropSide === 'before' && <div className="absolute -left-1 top-0 bottom-0 w-0.5 bg-gold rounded-full pointer-events-none" />}
-      {dropSide === 'after' && <div className="absolute -right-1 top-0 bottom-0 w-0.5 bg-gold rounded-full pointer-events-none" />}
-      <div
-        draggable={!isReadOnly}
-        onDragStart={e => {
-          if (isReadOnly) return
-          e.dataTransfer.effectAllowed = 'move'
-          e.dataTransfer.setData('text/plain', item.key)
-          onDragStart(item.key)
-        }}
-        onDragEnd={onDragEnd}
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        onMouseEnter={() => onHover(item.key)}
-        onFocus={() => onHover(item.key)}
-        tabIndex={isReadOnly ? -1 : 0}
-        className={`${tileFrameClass} overflow-hidden border bg-deep cursor-grab active:cursor-grabbing transition-colors ${
-          isPreviewed ? 'border-gold ring-1 ring-gold/40' : 'border-gold-dim/30 hover:border-gold/60'
-        } ${isDragging ? 'opacity-40' : ''} ${isReadOnly ? 'cursor-default active:cursor-default' : ''}`}
-        title={item.name}
-      >
-        <EntityImage
-          key={item.key}
-          src={tileSrcFor(item, listType)}
-          name={item.name}
-          className={tileImageClass}
-        />
-      </div>
-    </div>
-  )
-}
-
-function DetailPanel({ item, listType, hoverText }) {
-  const isPet = listType === 'pet'
-  const detailFrameClass = isPet
-    ? 'w-full max-w-sm aspect-[5/7] rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70'
-    : 'w-full max-w-lg aspect-[3/2] rounded-lg overflow-hidden border border-gold-dim/40 bg-deep shadow-2xl shadow-black/70'
-
-  if (!item) {
-    return (
-      <div className="bg-surface border border-gold-dim/15 rounded-xl p-6 flex items-center justify-center min-h-28">
-        <p className="text-muted text-sm font-body italic">{hoverText}</p>
-      </div>
-    )
-  }
-
-  function PetDetailArtwork() {
-    const [failed, setFailed] = useState(false)
-    if (failed) {
-      return (
-        <div className="w-full h-full p-6 flex flex-col items-center justify-center gap-3 text-center">
-          <p className="font-heading text-lg text-gold-light">{item.name}</p>
-          <p className="text-sm font-body text-parchment/80">
-            {item.ability_text ?? 'Image coming soon.'}
-          </p>
-        </div>
-      )
-    }
-    return (
-      <img
-        src={detailSrcFor(item, listType)}
-        alt={item.name}
-        className="w-full h-full object-contain p-1 bg-surface"
-        onError={() => setFailed(true)}
-      />
-    )
-  }
-
-  return (
-    <div className="bg-surface border border-gold-dim/20 rounded-xl p-6 flex flex-col items-center gap-4">
-      <div className="text-center">
-        <p className="text-xs font-body text-gold-dim uppercase tracking-widest mb-1">
-          {EXPANSION_LABELS[item.expansion] ?? item.expansion ?? ''}
-        </p>
-        <h3 className="font-heading text-2xl text-parchment tracking-wide">{item.name}</h3>
-      </div>
-      <div className={detailFrameClass}>
-        {listType === 'pet' ? (
-          <PetDetailArtwork key={item.key} />
-        ) : (
-          <EntityImage
-            src={detailSrcFor(item, listType)}
-            name={item.name}
-            className="w-full h-full object-cover"
-            fallbackTextSize="text-base"
-          />
-        )}
-      </div>
-      {listType === 'pet' && item.ability_text && (
-        <p className="text-sm font-body text-parchment/80 text-center max-w-lg">
-          {item.ability_text}
-        </p>
-      )}
-    </div>
-  )
-}
-
-function TierRow({
-  tier,
-  keys,
-  itemsByKey,
-  listType,
-  onDrop,
-  onDragOver,
-  onDragStart,
-  onDragEnd,
-  onHover,
-  onTileHover,
-  dropTarget,
-  draggingKey,
-  previewKey,
-  isOver,
-  emptyTier,
-  isReadOnly = false,
-}) {
-  const style = TIER_STYLES[tier]
-  const tileDropApi = {
-    hover: (beforeKey, side) => onTileHover(tier, beforeKey, side),
-    drop: (beforeKey, side) => onDrop(tier, { beforeKey, side }),
-  }
-
-  return (
-    <div
-      onDragOver={e => {
-        if (isReadOnly) return
-        e.preventDefault()
-        e.dataTransfer.dropEffect = 'move'
-        onDragOver(tier)
-      }}
-      onDrop={e => {
-        if (isReadOnly) return
-        e.preventDefault()
-        onDrop(tier)
-      }}
-      className={`flex items-stretch border rounded-lg overflow-hidden transition-colors ${style.row} ${isOver ? 'ring-2 ring-gold/60' : ''}`}
-    >
-      <div className={`flex items-center justify-center w-16 font-display text-3xl tracking-wider border-r ${style.label}`}>
-        {tier}
-      </div>
-      <div className="flex-1 min-h-[72px] p-2 flex flex-wrap gap-2 items-start">
-        {keys.length === 0 ? (
-          <span className="text-muted/60 text-xs font-body italic self-center px-2">{emptyTier}</span>
-        ) : (
-          keys.map(key => {
-            const item = itemsByKey.get(key)
-            if (!item) return null
-            const isDropTargetTile = dropTarget && dropTarget.tier === tier && dropTarget.beforeKey === key
-            return (
-              <TierTile
-                key={key}
-                item={item}
-                listType={listType}
-                onDragStart={onDragStart}
-                onDragEnd={onDragEnd}
-                onHover={onHover}
-                onTileDrop={tileDropApi}
-                isDragging={draggingKey === key}
-                isPreviewed={previewKey === key}
-                dropSide={isDropTargetTile ? dropTarget.side : null}
-                isReadOnly={isReadOnly}
-              />
-            )
-          })
-        )}
-      </div>
-    </div>
-  )
-}
-
-function Pool({
-  listType,
-  poolTitle,
-  emptyPool,
-  keys,
-  itemsByKey,
-  onDrop,
-  onDragOver,
-  onDragStart,
-  onDragEnd,
-  onHover,
-  draggingKey,
-  previewKey,
-  isOver,
-  isReadOnly = false,
-}) {
-  return (
-    <div
-      onDragOver={e => {
-        if (isReadOnly) return
-        e.preventDefault()
-        e.dataTransfer.dropEffect = 'move'
-        onDragOver('pool')
-      }}
-      onDrop={e => {
-        if (isReadOnly) return
-        e.preventDefault()
-        onDrop('pool')
-      }}
-      className={`bg-surface border border-gold-dim/20 rounded-xl p-4 transition-colors ${isOver ? 'ring-2 ring-gold/60' : ''}`}
-    >
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="font-heading text-lg text-parchment tracking-wide">{poolTitle}</h2>
-        <span className="text-xs font-body text-muted">{keys.length} unranked</span>
-      </div>
-      <div className="flex flex-wrap gap-2 min-h-[72px]">
-        {keys.length === 0 ? (
-          <p className="text-muted text-sm font-body italic">{emptyPool}</p>
-        ) : (
-          keys.map(key => {
-            const item = itemsByKey.get(key)
-            if (!item) return null
-            return (
-              <TierTile
-                key={key}
-                item={item}
-                listType={listType}
-                onDragStart={onDragStart}
-                onDragEnd={onDragEnd}
-                onHover={onHover}
-                isDragging={draggingKey === key}
-                isPreviewed={previewKey === key}
-                isReadOnly={isReadOnly}
-              />
-            )
-          })
-        )}
-      </div>
-    </div>
-  )
-}
 
 export default function Tierlist() {
   const { id: playerId } = useParams()
@@ -405,11 +54,8 @@ export default function Tierlist() {
 
   const [tiers, setTiers] = useState(EMPTY_TIERS)
   const [isDirty, setIsDirty] = useState(false)
-  const [draggingKey, setDraggingKey] = useState(null)
-  const [overZone, setOverZone] = useState(null)
   const [seededAt, setSeededAt] = useState(null)
   const [previewKey, setPreviewKey] = useState(null)
-  const [dropTarget, setDropTarget] = useState(null)
 
   const queryStamp = `${listType}:${tierlistQuery.dataUpdatedAt}`
   if (tierlistQuery.data && sourceReady && seededAt !== queryStamp) {
@@ -433,44 +79,6 @@ export default function Tierlist() {
     return () => window.removeEventListener('beforeunload', handler)
   }, [isDirty])
 
-  useEffect(() => {
-    if (!draggingKey) return
-    const NAV_OFFSET = 64
-    const EDGE = 100
-    const MAX_SPEED = 18
-    let cursorY = -1
-    let frame = 0
-
-    const onDragOver = e => {
-      cursorY = e.clientY
-    }
-
-    const tick = () => {
-      const h = window.innerHeight
-      let speed = 0
-      if (cursorY >= 0) {
-        const topZoneEnd = NAV_OFFSET + EDGE
-        if (cursorY < topZoneEnd) {
-          const intensity = Math.max(0, (topZoneEnd - cursorY) / EDGE)
-          speed = -Math.ceil(intensity * MAX_SPEED)
-        } else if (cursorY > h - EDGE) {
-          const intensity = Math.min(1, (cursorY - (h - EDGE)) / EDGE)
-          speed = Math.ceil(intensity * MAX_SPEED)
-        }
-      }
-      if (speed !== 0) window.scrollBy(0, speed)
-      frame = requestAnimationFrame(tick)
-    }
-
-    window.addEventListener('dragover', onDragOver)
-    frame = requestAnimationFrame(tick)
-
-    return () => {
-      window.removeEventListener('dragover', onDragOver)
-      cancelAnimationFrame(frame)
-    }
-  }, [draggingKey])
-
   const placedKeys = useMemo(() => {
     const set = new Set()
     for (const t of TIERS) for (const k of tiers[t] ?? []) set.add(k)
@@ -484,46 +92,11 @@ export default function Tierlist() {
 
   const previewItem = itemsByKey.get(previewKey ?? poolKeys[0]) ?? null
 
-  const handleDragStart = key => setDraggingKey(key)
-  const handleDragEnd = () => {
-    setDraggingKey(null)
-    setOverZone(null)
-    setDropTarget(null)
-  }
-  const handleDragOver = zone => {
-    setOverZone(zone)
-    setDropTarget(null)
-  }
-  const handleTileHover = (tier, beforeKey, side) => {
-    setOverZone(tier)
-    setDropTarget({ tier, beforeKey, side })
-  }
-  const handleHover = key => setPreviewKey(prev => (prev === key ? prev : key))
+  const handlePreview = key => setPreviewKey(prev => (prev === key ? prev : key))
 
-  const handleDrop = (targetZone, opts) => {
-    if (!draggingKey) return
-
-    setTiers(prev => {
-      const next = {}
-      for (const t of TIERS) next[t] = (prev[t] ?? []).filter(k => k !== draggingKey)
-      if (targetZone !== 'pool') {
-        const tierArr = next[targetZone]
-        if (opts && opts.beforeKey && opts.beforeKey !== draggingKey) {
-          let idx = tierArr.indexOf(opts.beforeKey)
-          if (idx === -1) idx = tierArr.length
-          if (opts.side === 'after') idx += 1
-          next[targetZone] = [...tierArr.slice(0, idx), draggingKey, ...tierArr.slice(idx)]
-        } else {
-          next[targetZone] = [...tierArr, draggingKey]
-        }
-      }
-      return next
-    })
-
+  const handleMove = (key, targetZone, opts) => {
+    setTiers(prev => moveKeyInTiers(prev, key, targetZone, opts))
     setIsDirty(true)
-    setDraggingKey(null)
-    setOverZone(null)
-    setDropTarget(null)
   }
 
   const handleSave = () => {
@@ -546,9 +119,6 @@ export default function Tierlist() {
     if (nextType === listType) return
     if (isDirty && !window.confirm('You have unsaved changes. Switch list anyway?')) return
 
-    setDraggingKey(null)
-    setOverZone(null)
-    setDropTarget(null)
     setPreviewKey(null)
 
     setSearchParams(prev => {
@@ -576,6 +146,19 @@ export default function Tierlist() {
     (listType === 'pet' ? petsQuery.isLoading : iconsQuery.isLoading) ||
     (isPlayerVisible && tierlistQuery.isLoading)
 
+  const boardProps = {
+    tiers,
+    poolKeys,
+    itemsByKey,
+    listType,
+    config,
+    previewItem,
+    previewKey,
+    onPreview: handlePreview,
+    onMove: handleMove,
+    isReadOnly: !canEdit,
+  }
+
   return (
     <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <div className="mb-6 animate-fade-up">
@@ -591,9 +174,14 @@ export default function Tierlist() {
             <h1 className="font-heading text-3xl text-parchment tracking-wide">
               {player ? `${player.name}'s Tierlists` : 'Tierlists'}
             </h1>
-            <p className="text-muted text-sm font-body mt-1">
+            <p className="hidden md:block text-muted text-sm font-body mt-1">
               {canEdit
                 ? config.editHint
+                : 'Read only view. Only the tierlist owner can edit.'}
+            </p>
+            <p className="md:hidden text-muted text-sm font-body mt-1">
+              {canEdit
+                ? config.mobileEditHint
                 : 'Read only view. Only the tierlist owner can edit.'}
             </p>
           </div>
@@ -650,50 +238,12 @@ export default function Tierlist() {
       {isLoading ? (
         <p className="text-muted text-sm font-body italic">Loading...</p>
       ) : (
-        <div className="space-y-3 animate-fade-up delay-1">
-          {TIERS.map(t => (
-            <TierRow
-              key={t}
-              tier={t}
-              keys={tiers[t] ?? []}
-              itemsByKey={itemsByKey}
-              listType={listType}
-              onDrop={handleDrop}
-              onDragOver={handleDragOver}
-              onDragStart={handleDragStart}
-              onDragEnd={handleDragEnd}
-              onHover={handleHover}
-              onTileHover={handleTileHover}
-              dropTarget={dropTarget}
-              draggingKey={draggingKey}
-              previewKey={previewKey}
-              isOver={overZone === t}
-              emptyTier={config.emptyTier}
-              isReadOnly={!canEdit}
-            />
-          ))}
-
-          <div className="pt-4">
-            <Pool
-              listType={listType}
-              poolTitle={config.poolTitle}
-              emptyPool={config.emptyPool}
-              keys={poolKeys}
-              itemsByKey={itemsByKey}
-              onDrop={handleDrop}
-              onDragOver={handleDragOver}
-              onDragStart={handleDragStart}
-              onDragEnd={handleDragEnd}
-              onHover={handleHover}
-              draggingKey={draggingKey}
-              previewKey={previewKey}
-              isOver={overZone === 'pool'}
-              isReadOnly={!canEdit}
-            />
+        <div className="animate-fade-up delay-1">
+          <div className="md:hidden">
+            <MobileTierBoard {...boardProps} />
           </div>
-
-          <div className="pt-4">
-            <DetailPanel item={previewItem} listType={listType} hoverText={config.hoverText} />
+          <div className="hidden md:block">
+            <DesktopTierBoard {...boardProps} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Split the tierlist page so desktop drag/drop and mobile touch editing live in separate board components.
- Added a mobile tap-to-select flow with tier, Before, After, End, and pool placement actions.
- Moved shared tierlist constants, image rendering, details panel, and move helper into shared tierlist modules.

## Validation
- `npm run lint`
- `npm run build`

Note: this uses the current branch as requested, which already contained the existing `Add legal notice and takedown contact` commit before the tierlist commit.
