### PR TITLE
Support spell PvP kills and peasant mob deaths

### DIFF
--- a/src/pages/LogGame.jsx
+++ b/src/pages/LogGame.jsx
@@ -190,6 +190,10 @@ export default function LogGame({ initialData, isEditing, gameId, canDelete = tr
   }
 
   const pvpDeathTypeId = allDeathTypes.find(dt => dt.name === 'PVP')?.id
+  const playerKillAttributionDeathTypeIds = allDeathTypes
+    .filter(dt => dt.name === 'PVP' || dt.name === 'Spell')
+    .map(dt => dt.id)
+  const canAttributeKiller = (deathTypeId) => playerKillAttributionDeathTypeIds.includes(deathTypeId)
 
   const addDeath = (playerId) => {
     setForm(prev => {
@@ -214,7 +218,7 @@ export default function LogGame({ initialData, isEditing, gameId, canDelete = tr
     setForm(prev => {
       const deaths = [...(prev.playerData[playerId]?.deaths ?? [])]
       deaths[idx] = { ...deaths[idx], [field]: value }
-      if (field === 'death_type_id' && value !== pvpDeathTypeId) {
+      if (field === 'death_type_id' && !canAttributeKiller(value)) {
         deaths[idx].killed_by_player_id = null
       }
       return {
@@ -779,7 +783,7 @@ export default function LogGame({ initialData, isEditing, gameId, canDelete = tr
                                     <option key={dt.id} value={dt.id}>{dt.name}</option>
                                   ))}
                                 </select>
-                                {death.death_type_id === pvpDeathTypeId && (
+                                {canAttributeKiller(death.death_type_id) && (
                                   <select
                                     className="input-field text-sm flex-1 min-w-[120px]"
                                     value={death.killed_by_player_id || ''}

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -616,7 +616,7 @@ function DeathsTab({ games }) {
         </section>
       </div>
       <section>
-        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">PVP Kill Leaderboard</h3>
+        <h3 className="font-heading text-lg text-parchment tracking-wide mb-3">Player Kill Leaderboard</h3>
         <StatsTable
           columns={pvpColumns}
           rows={pvpRows}

--- a/supabase/migrations/20260601125322_add_peasant_mob_death_type.sql
+++ b/supabase/migrations/20260601125322_add_peasant_mob_death_type.sql
@@ -1,0 +1,4 @@
+insert into death_types (name, description)
+values ('Peasant Mob', 'Killed by a peasant mob')
+on conflict (name) do update set
+  description = excluded.description;


### PR DESCRIPTION
## Summary
- Allow Spell deaths to carry a killed-by player attribution, alongside PVP deaths
- Rename the death stats kill table to Player Kill Leaderboard
- Add a Peasant Mob death type migration

## Verification
- npm run lint
- npm run build
- npx supabase db push

Closes #131
Closes #132