### PR TITLE
Fix best character zero win selection

### DIFF
--- a/src/lib/statsHelpers.js
+++ b/src/lib/statsHelpers.js
@@ -104,6 +104,7 @@ export function computeLeaderboard(gamePlayers, deathTypesByPlayer = new Map(), 
       for (const [char, gamesCount] of row.character_counts) {
         if (gamesCount < 2) continue
         const charWins = row.character_wins.get(char) ?? 0
+        if (charWins === 0) continue
         const rate = charWins / gamesCount
         if (rate > bestCharWinRate || (rate === bestCharWinRate && gamesCount > bestCharGames)) {
           bestCharacter = char


### PR DESCRIPTION
## What changed

- Updated leaderboard best-character selection to ignore 0-win characters during the minimum-2-games win-rate pass.
- Preserved the existing fallback to most wins, so a player with wins on lower-played characters still gets a real best character.

## Why

A character with multiple games and 0 wins could be selected before the fallback ran, causing the leaderboard to show values like `Leprechaun (0%)` as the best character.

## Validation

- Direct regression calculation with `computeLeaderboard` now returns the winning character instead of the 0% character.
- `npm run lint`
- `npm run build`